### PR TITLE
Native Resolve All

### DIFF
--- a/Native/Dependencies/Containers/DependencyContainer.cs
+++ b/Native/Dependencies/Containers/DependencyContainer.cs
@@ -39,7 +39,7 @@ namespace Chopsticks.Dependencies.Containers
         public void Dispose()
         {
             if (Parent != null)
-                foreach (var resolution in Parent.GetResolutions())
+                foreach (var resolution in Parent.GetResolutionsForDisposal())
                     resolution.DisposeFor(this);
 
             foreach (var resolutions in _resolutions.Values)
@@ -144,11 +144,15 @@ namespace Chopsticks.Dependencies.Containers
         }
 
         /// <inheritdoc/>
-        IEnumerable<DependencyResolution> IDependencyResolutionProvider.GetResolutions(
-            Type contract)
+        IEnumerable<DependencyResolution> IDependencyResolutionProvider.GetResolutionsForDisposal()
         {
-            // TODO :: Implement.
-            return [];
+            foreach (var resolutions in _resolutions.Values)
+                foreach (var resolution in resolutions)
+                    yield return resolution;
+
+            if (Parent != null)
+                foreach (var resolution in Parent.GetResolutionsForDisposal())
+                    yield return resolution;
         }
     }
 }

--- a/Native/Dependencies/Containers/DependencyContainer.cs
+++ b/Native/Dependencies/Containers/DependencyContainer.cs
@@ -1,7 +1,6 @@
 ﻿using Chopsticks.Dependencies.Resolutions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Chopsticks.Dependencies.Containers
 {
@@ -122,12 +121,6 @@ namespace Chopsticks.Dependencies.Containers
 
         /// <inheritdoc/>
         public IEnumerable<object> ResolveAll(Type contract)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc/>
-        public void ResolveAllSingletons()
         {
             throw new NotImplementedException();
         }

--- a/Native/Dependencies/Containers/IDependencyContainer.cs
+++ b/Native/Dependencies/Containers/IDependencyContainer.cs
@@ -63,13 +63,5 @@ namespace Chopsticks.Dependencies.Containers
         /// <param name="contract">The type of the contract to be resolved.</param>
         /// <returns>The collection of all resolving implementations..</returns>
         IEnumerable<object> ResolveAll(Type contract);
-
-        /// <summary>
-        /// Resolves all dependencies that will be singletons within the scope of this container, 
-        /// which will include those registered with a lifetime of either
-        /// <see cref="DependencyLifetime.Singleton"/> or 
-        /// <see cref="DependencyLifetime.Contained"/>.
-        /// </summary>
-        void ResolveAllSingletons();
     }
 }

--- a/Native/Dependencies/Resolutions/IDependencyResolutionProvider.cs
+++ b/Native/Dependencies/Resolutions/IDependencyResolutionProvider.cs
@@ -24,18 +24,21 @@ namespace Chopsticks.Dependencies.Resolutions
         DependencyResolution? GetResolution(Type contract);
 
         /// <summary>
-        /// Provides all resolutions known to this provider.
-        /// </summary>
-        /// <returns>All resolutions. If there are none, 
-        /// the returned collection will be empty.</returns>
-        IEnumerable<DependencyResolution> GetResolutions();
-
-        /// <summary>
         /// Provides all resolutions that will resolve the specified contract.
         /// </summary>
         /// <param name="contract">The type of the contract.</param>
         /// <returns>All resolving resolutions. If there are none, 
         /// the returned collection will be empty.</returns>
         IEnumerable<DependencyResolution> GetResolutions(Type contract);
+
+        /// <summary>
+        /// Provides all disposable resolutions known to this provider.
+        /// </summary>
+        /// <remarks>
+        /// This includes all resolutions of a parent provider.
+        /// </remarks>
+        /// <returns>All disposable resolutions. If there are none, 
+        /// the returned collection will be empty.</returns>
+        IEnumerable<DependencyResolution> GetResolutionsForDisposal();
     }
 }

--- a/Native/Dependencies/Tests/DependencyContainerTests/CanProvide.cs
+++ b/Native/Dependencies/Tests/DependencyContainerTests/CanProvide.cs
@@ -10,8 +10,6 @@ public class CanProvide
         public interface IContractA { }
 
         public interface IContractB { }
-
-        public class ImplementationA : IContractA { }
     }
 
 

--- a/Native/Dependencies/Tests/DependencyContainerTests/Resolve.cs
+++ b/Native/Dependencies/Tests/DependencyContainerTests/Resolve.cs
@@ -142,6 +142,36 @@ public class Resolve
 
 
     [Test]
+    public void Resolve_ChildWithoutInheritance_False()
+    {
+        // Set up
+        var container = SetUp.ChildContainer(out _, out _, out _, out _);
+        container.InheritParentDependencies = false;
+
+        // Act
+        var resolved = container.Resolve(typeof(Mock.IContractA), out _);
+
+        // Assert
+        Assert.That(resolved, Is.False);
+    }
+
+    [Test]
+    public void Resolve_ChildWithoutInheritance_OutsNull()
+    {
+        // Set up
+        var container = SetUp.ChildContainer(out _, out var parentResolution, out _, out _);
+        container.InheritParentDependencies = false;
+
+        // Act
+        container.Resolve(typeof(Mock.IContractA), out var resolvedImplementation);
+
+        // Assert
+        Assert.That(resolvedImplementation, Is.Null);
+        parentResolution.DidNotReceive().Get(container);
+    }
+
+
+    [Test]
     public void Resolve_DeregisteredAllAfterMultiRegistration_False()
     {
         // Set up

--- a/Native/Dependencies/Tests/DependencyContainerTests/ResolveAll.cs
+++ b/Native/Dependencies/Tests/DependencyContainerTests/ResolveAll.cs
@@ -1,0 +1,247 @@
+﻿using Chopsticks.Dependencies.Containers;
+using Chopsticks.Dependencies.Resolutions;
+using NSubstitute;
+
+namespace DependencyContainerTests;
+
+public class ResolveAll
+{
+    public static class Mock
+    {
+        public interface IContractA { }
+
+        public interface IContractB { }
+
+        public interface IContractC { }
+    }
+
+    public static class SetUp
+    {
+        public static DependencyContainer ChildContainer(
+            out DependencyResolution parentResolution1,
+            out DependencyResolution parentResolution2,
+            out DependencyResolution childResolution)
+        {
+            var parentSpec1 = new DependencySpecification()
+            {
+                Contract = typeof(Mock.IContractA),
+                ImplementationFactory = _ => Substitute.For<Mock.IContractA>()
+            };
+            var parentSpec2 = new DependencySpecification()  // For verifying exclusion.
+            {
+                Contract = typeof(Mock.IContractB),
+                ImplementationFactory = _ => Substitute.For<Mock.IContractB>()
+            };
+            var childSpec = new DependencySpecification()
+            {
+                Contract = typeof(Mock.IContractA),
+                ImplementationFactory = _ => Substitute.For<Mock.IContractA>()
+            };
+
+            var parentFactory = Substitute.For<IDependencyResolutionFactory>();
+            var parentContainer = new DependencyContainer(parentFactory);
+            parentResolution1 = ConfigureFactoryForSpec(parentFactory, 
+                parentContainer, parentSpec1);
+            parentResolution2 = ConfigureFactoryForSpec(parentFactory, 
+                parentContainer, parentSpec2);
+            parentContainer.Register(parentSpec1, out _);
+
+            var childFactory = Substitute.For<IDependencyResolutionFactory>();
+            var childContainer = new DependencyContainer(childFactory)
+            {
+                InheritParentDependencies = true,
+                Parent = parentContainer
+            };
+            parentResolution1.Get(childContainer)
+                .Returns(parentSpec1.ImplementationFactory(childContainer));
+            parentResolution2.Get(childContainer)
+                .Returns(parentSpec2.ImplementationFactory(childContainer));
+            childResolution = ConfigureFactoryForSpec(childFactory, childContainer, childSpec);
+
+            return childContainer;
+        }
+
+        public static DependencyContainer StandardContainer(
+            out DependencyResolution firstResolution,
+            out DependencyResolution secondResolution,
+            out DependencyRegistration firstRegistration,
+            out DependencyRegistration secondRegistration)
+        {
+            var firstSpec = new DependencySpecification()
+            {
+                Contract = typeof(Mock.IContractA),
+                ImplementationFactory = _ => Substitute.For<Mock.IContractA>()
+            };
+            var secondSpec = new DependencySpecification()
+            {
+                Contract = typeof(Mock.IContractA),
+                ImplementationFactory = _ => Substitute.For<Mock.IContractA>()
+            };
+            var thirdSpec = new DependencySpecification()  // For verifying exclusion.
+            {
+                Contract = typeof(Mock.IContractB),
+                ImplementationFactory = _ => Substitute.For<Mock.IContractB>()
+            };
+
+            var factory = Substitute.For<IDependencyResolutionFactory>();
+            var container = new DependencyContainer(factory);
+            firstResolution = ConfigureFactoryForSpec(factory, container, firstSpec);
+            secondResolution = ConfigureFactoryForSpec(factory, container, secondSpec);
+            ConfigureFactoryForSpec(factory, container, thirdSpec);
+            container
+                .Register(firstSpec, out firstRegistration)
+                .Register(secondSpec, out secondRegistration)
+                .Register(thirdSpec, out _);
+
+            return container;
+        }
+
+
+        private static DependencyResolution ConfigureFactoryForSpec(
+            IDependencyResolutionFactory factory,
+            IDependencyContainer container,
+            DependencySpecification spec)
+        {
+            var mockDependency = Substitute.For<Mock.IContractA>();
+
+            var resolution = Substitute.For<DependencyResolution>(
+                spec.Contract,
+                spec.ImplementationFactory);
+            resolution.Get(container).Returns(mockDependency);
+
+            factory.BuildResolutionFor(spec).Returns(_ => resolution);
+
+            return resolution;
+        }
+    }
+
+
+    [Test]
+    public void ResolveAll_AfterDispose_ReturnsEmpty()
+    {
+        // Set up
+        var container = SetUp.StandardContainer(out _, out _, out _, out _);
+        container.Dispose();
+
+        // Act
+        var instances = container.ResolveAll(typeof(Mock.IContractA));
+
+        // Assert
+        Assert.That(instances, Is.Empty);
+    }
+
+
+    [Test]
+    public void ResolveAll_DeregisteredAll_ReturnsEmpty()
+    {
+        // Set up
+        var container = SetUp.StandardContainer(
+            out _, out _, out var firstRegistration, out var secondRegistration);
+        container.Deregister(firstRegistration)
+            .Deregister(secondRegistration);
+
+        // Act
+        var instances = container.ResolveAll(typeof(Mock.IContractA));
+
+        // Assert
+        Assert.That(instances, Is.Empty);
+    }
+
+    [Test]
+    public void ResolveAll_DeregisteredFirst_ReturnsOnlySecondResolutionInstance()
+    {
+        // Set up
+        var container = SetUp.StandardContainer(
+            out _, out var secondResolution, out var firstRegistration, out _);
+        container.Deregister(firstRegistration);
+
+        // Act
+        var instances = container.ResolveAll(typeof(Mock.IContractA)).ToArray();
+
+        // Assert
+        Assert.That(instances.Length, Is.EqualTo(1));
+        Assert.That(secondResolution.Get(container), Is.EqualTo(instances[0]));
+    }
+
+    [Test]
+    public void ResolveAll_DeregisteredSecond_ReturnsOnlyFirstResolutionInstance()
+    {
+        // Set up
+        var container = SetUp.StandardContainer(
+            out var firstResolution, out _, out _, out var secondRegistration);
+        container.Deregister(secondRegistration);
+
+        // Act
+        var instances = container.ResolveAll(typeof(Mock.IContractA)).ToArray();
+
+        // Assert
+        Assert.That(instances.Length, Is.EqualTo(1));
+        Assert.That(firstResolution.Get(container), Is.EqualTo(instances[0]));
+    }
+
+
+    [Test]
+    public void ResolveAll_Inherited_ReturnsOwnAndParentInstances()
+    {
+        // Set up
+        var container = SetUp.ChildContainer(
+            out var parentResolution1, out var parentResolution2, out var childResolution);
+
+        // Act
+        var instances = container.ResolveAll(typeof(Mock.IContractA)).ToArray();
+
+        // Assert
+        Assert.That(instances.Length, Is.EqualTo(3));
+        Assert.That(childResolution.Get(container), Is.EqualTo(instances[0]));
+        Assert.That(parentResolution1.Get(container), Is.EqualTo(instances[1]));
+        Assert.That(parentResolution2.Get(container), Is.EqualTo(instances[2]));
+    }
+
+    [Test]
+    public void ResolveAll_InheritedAfterDispose_ReturnsOnlyParentInstances()
+    {
+        // Set up
+        var container = SetUp.ChildContainer(
+            out var parentResolution1, out var parentResolution2, out var childResolution);
+        container.Dispose();
+
+        // Act
+        var instances = container.ResolveAll(typeof(Mock.IContractA)).ToArray();
+
+        // Assert
+        Assert.That(instances.Length, Is.EqualTo(2));
+        Assert.That(parentResolution1.Get(container), Is.EqualTo(instances[0]));
+        Assert.That(parentResolution2.Get(container), Is.EqualTo(instances[1]));
+    }
+
+
+    [Test]
+    public void ResolveAll_Registered_ReturnsInstances()
+    {
+        // Set up
+        var container = SetUp.StandardContainer(out var firstResolution, out var secondResolution,
+            out _, out _);
+
+        // Act
+        var instances = container.ResolveAll(typeof(Mock.IContractA)).ToArray();
+
+        // Assert
+        Assert.That(instances.Length, Is.EqualTo(2));
+        Assert.That(firstResolution.Get(container), Is.EqualTo(instances[0]));
+        Assert.That(secondResolution.Get(container), Is.EqualTo(instances[1]));
+    }
+
+
+    [Test]
+    public void ResolveAll_Unregistered_ReturnsEmpty()
+    {
+        // Set up
+        var container = new DependencyContainer();
+
+        // Act
+        var instances = container.ResolveAll(typeof(Mock.IContractB));
+
+        // Assert
+        Assert.That(instances, Is.Empty);
+    }
+}


### PR DESCRIPTION
### What Changed?
- Implemented DependencyContainer.ResolveAll.
- Corrected some parenting issues with the InheritParentDependencies flag being unaccounted for and Disposal on considering grandparents.
### Why It Changed
- To accommodate use cases where multiple resolutions to a single contract may exist and need to all be retrieved.
### How to Test
- Verify unit tests pass.