### PR TITLE
Support Native Container Extensions

### DIFF
--- a/Native/Dependencies/Containers/DependencySpecification.cs
+++ b/Native/Dependencies/Containers/DependencySpecification.cs
@@ -23,7 +23,7 @@ namespace Chopsticks.Dependencies.Containers
         /// The factory method that can produce an instance of an implementation to 
         /// resolve this dependency.
         /// </summary>
-        public required Func<IDependencyContainer, object> ImplementationFactory { get; init; }
+        public required Func<IDependencyContainer, object?> ImplementationFactory { get; init; }
 
 
         /// <summary>

--- a/Native/Dependencies/Containers/IDependencyContainerExtensions.cs
+++ b/Native/Dependencies/Containers/IDependencyContainerExtensions.cs
@@ -9,6 +9,10 @@ namespace Chopsticks.Dependencies.Containers
     /// </summary>
     public static class IDependencyContainerExtensions
     {
+        private const string DefaultErrorMessage = "The requested dependency of type " +
+            "{0} could not be resolved or resolved with null.";
+
+
         /// <summary>
         /// Registers the dependency defined by the given specification.
         /// </summary>
@@ -111,14 +115,20 @@ namespace Chopsticks.Dependencies.Containers
         /// <typeparam name="TContract">The type of the contract is to be resolved.</typeparam>
         /// <param name="container">The container resolving the dependency.</param>
         /// <param name="customErrorMessage">The custom message of the exception 
-        /// thrown if the dependency could not be resolved.</param>
+        /// thrown if the dependency could not be resolved or was resolved as null.</param>
         /// <exception cref="MissingDependencyException">Thrown if the specified 
-        /// dependency could not be resolved.</exception>
+        /// dependency could not be resolved or was resolved as null.</exception>
         /// <returns>The resolved dependency.</returns>
         public static TContract AssertiveResolve<TContract>(
-            this IDependencyContainer container, string? customErrorMessage = null)
+            this IDependencyContainer container, 
+            string? customErrorMessage = null)
         {
-            throw new NotImplementedException();
+            var wasResolved = container.Resolve(typeof(TContract), out var uncastImplementation);
+            if (wasResolved && uncastImplementation is TContract implementation)
+                return implementation;
+
+            throw new MissingDependencyException(customErrorMessage ?? 
+                string.Format(DefaultErrorMessage, typeof(TContract).FullName));
         }
 
         /// <summary>
@@ -132,10 +142,16 @@ namespace Chopsticks.Dependencies.Containers
         /// <exception cref="MissingDependencyException">Thrown if the specified 
         /// dependency could not be resolved.</exception>
         /// <returns>The resolving dependency implementation.</returns>
-        public static object AssertiveResolve(this IDependencyContainer container, Type contract,
+        public static object AssertiveResolve(
+            this IDependencyContainer container, 
+            Type contract,
             string? customErrorMessage = null)
         {
-            throw new NotImplementedException();
+            if (container.Resolve(contract, out var implementation) && implementation is not null)
+                return implementation;
+
+            throw new MissingDependencyException(customErrorMessage ??
+                string.Format(DefaultErrorMessage, contract.FullName));
         }
 
         /// <summary>
@@ -151,7 +167,9 @@ namespace Chopsticks.Dependencies.Containers
             this IDependencyContainer container,
             out TContract? implementation)
         {
-            throw new NotImplementedException();
+            var wasResolved = container.Resolve(typeof(TContract), out var uncastImplementation);
+            implementation = (TContract?)uncastImplementation;
+            return wasResolved;
         }
 
         /// <summary>
@@ -163,7 +181,8 @@ namespace Chopsticks.Dependencies.Containers
         public static IEnumerable<TContract> ResolveAll<TContract>(
             this IDependencyContainer container)
         {
-            throw new NotImplementedException();
+            foreach (var implementation in container.ResolveAll(typeof(TContract)))
+                yield return (TContract)implementation;
         }
     }
 }

--- a/Native/Dependencies/Containers/IDependencyContainerExtensions.cs
+++ b/Native/Dependencies/Containers/IDependencyContainerExtensions.cs
@@ -1,53 +1,107 @@
 ﻿using Chopsticks.Dependencies.Exceptions;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 
 namespace Chopsticks.Dependencies.Containers
 {
+    /// <summary>
+    /// Extensions for <see cref="IDependencyContainer"/>.
+    /// </summary>
     public static class IDependencyContainerExtensions
     {
-
-
+        /// <summary>
+        /// Registers the dependency defined by the given specification.
+        /// </summary>
+        /// <param name="container">The container registering the dependency.</param>
+        /// <param name="specification">The specification that defines the 
+        /// dependency to be registered.</param>
+        /// <returns>This container, to chain additional manipulations.</returns>
         public static IDependencyContainer Register(
             this IDependencyContainer container,
-            DependencySpecification specification)
-        {
-            throw new NotImplementedException();
-        }
+            DependencySpecification specification) =>
+                container.Register(specification, out _);
 
-        // TODO :: Re-evaluate with specifying only contract.
-
+        /// <summary>
+        /// Registers the dependency defined by the given instance of the dependency, 
+        /// with a lifetime of <see cref="DependencyLifetime.Singleton"/>.
+        /// </summary>
+        /// <param name="container">The container registering the dependency.</param>
+        /// <param name="dependency">The instance of the dependency.</param>
+        /// <returns>This container, to chain additional manipulations.</returns>
         public static IDependencyContainer Register<TContract>(
             this IDependencyContainer container,
-            TContract dependency)
-        {
-            throw new NotImplementedException();
-        }
+            TContract dependency) =>
+                container.Register(new DependencySpecification()
+                {
+                    Contract = typeof(TContract),
+                    ImplementationFactory = c => dependency,
+                    Lifetime = DependencyLifetime.Singleton,
+                }, out _);
 
+        /// <summary>
+        /// Registers the dependency defined by the given instance of the dependency, 
+        /// with a lifetime of <see cref="DependencyLifetime.Singleton"/>.
+        /// </summary>
+        /// <param name="container">The container registering the dependency.</param>
+        /// <param name="dependency">The instance of the dependency.</param>
+        /// <param name="registration">The registration that can identify the dependency for 
+        /// deregistration by <see cref="IDependencyContainer.Deregister(DependencyRegistration)"/>
+        /// </param>
+        /// <returns>This container, to chain additional manipulations.</returns>
         public static IDependencyContainer Register<TContract>(
             this IDependencyContainer container,
-            TContract dependency, out DependencyRegistration registration)
-        {
-            throw new NotImplementedException();
-        }
+            TContract dependency, 
+            out DependencyRegistration registration) =>
+                container.Register(new DependencySpecification()
+                {
+                    Contract = typeof(TContract),
+                    ImplementationFactory = c => dependency,
+                    Lifetime = DependencyLifetime.Singleton,
+                }, out registration);
 
+        /// <summary>
+        /// Registers the dependency defined by the given implementation factory.
+        /// </summary>
+        /// <param name="container">The container registering the dependency.</param>
+        /// <param name="implementationFactory">The factory for producing 
+        /// resolving implementations.</param>
+        /// <param name="lifetime">The lifetime of that the registered 
+        /// dependency will have.</param>
+        /// <returns>This container, to chain additional manipulations.</returns>
         public static IDependencyContainer Register<TContract>(
             this IDependencyContainer container,
-            Func<IDependencyContainer, TContract> dependencyFactory,
-            DependencyLifetime lifetime = DependencyLifetime.Singleton)
-        {
-            throw new NotImplementedException();
-        }
+            Func<IDependencyContainer, TContract> implementationFactory,
+            DependencyLifetime lifetime = DependencyLifetime.Singleton) =>
+                container.Register(new DependencySpecification()
+                {
+                    Contract = typeof(TContract),
+                    ImplementationFactory = c => implementationFactory(c),
+                    Lifetime = lifetime,
+                }, out _);
 
+        /// <summary>
+        /// Registers the dependency defined by the given implementation factory.
+        /// </summary>
+        /// <param name="container">The container registering the dependency.</param>
+        /// <param name="implementationFactory">The factory for producing 
+        /// resolving implementations.</param>
+        /// <param name="registration">The registration that can identify the dependency for 
+        /// deregistration by <see cref="IDependencyContainer.Deregister(DependencyRegistration)"/>
+        /// </param>
+        /// <param name="lifetime">The lifetime of that the registered 
+        /// dependency will have.</param>
+        /// <returns>This container, to chain additional manipulations.</returns>
         public static IDependencyContainer Register<TContract>(
             this IDependencyContainer container,
-            Func<IDependencyContainer, TContract> dependencyFactory,
+            Func<IDependencyContainer, TContract> implementationFactory,
             out DependencyRegistration registration,
-            DependencyLifetime lifetime = DependencyLifetime.Singleton)
-        {
-            throw new NotImplementedException();
-        }
+            DependencyLifetime lifetime = DependencyLifetime.Singleton) =>
+                container.Register(new DependencySpecification()
+                {
+                    Contract = typeof(TContract),
+                    ImplementationFactory = c => implementationFactory(c),
+                    Lifetime = lifetime,
+                }, out registration);
 
 
         /// <summary>
@@ -94,7 +148,7 @@ namespace Chopsticks.Dependencies.Containers
         /// if it could not be resolved.</param>
         /// <returns>Whether the dependency was successfully resolved.</returns>
         public static bool Resolve<TContract>(
-            this IDependencyContainer container, 
+            this IDependencyContainer container,
             out TContract? implementation)
         {
             throw new NotImplementedException();

--- a/Native/Dependencies/Exceptions/MissingDependencyException.cs
+++ b/Native/Dependencies/Exceptions/MissingDependencyException.cs
@@ -5,5 +5,6 @@ namespace Chopsticks.Dependencies.Exceptions
     /// <summary>
     /// Represents a failure to resolve a required dependency.
     /// </summary>
-    public class MissingDependencyException : Exception { }
+    /// <param name="message">The message that describes the error.</param>
+    public class MissingDependencyException(string message) : Exception(message);
 }

--- a/Native/Dependencies/Resolutions/ContainedResolution.cs
+++ b/Native/Dependencies/Resolutions/ContainedResolution.cs
@@ -10,7 +10,7 @@ namespace Chopsticks.Dependencies.Resolutions
     /// of <see cref="DependencyLifetime.Contained"/>.
     /// </remarks>
     public class ContainedResolution(Type contract,
-        Func<IDependencyContainer, object> factory) :
+        Func<IDependencyContainer, object?> factory) :
         DependencyResolution(contract, factory)
     {
         private readonly Dictionary<IDependencyContainer, object> _instances = new(1);

--- a/Native/Dependencies/Resolutions/DependencyResolution.cs
+++ b/Native/Dependencies/Resolutions/DependencyResolution.cs
@@ -10,7 +10,7 @@ namespace Chopsticks.Dependencies.Resolutions
     /// <param name="contract">The contract that this resolution fulfills.</param>
     /// <param name="factory">The factory that provides implementations for resolution.</param>
     public abstract class DependencyResolution(Type contract,
-        Func<IDependencyContainer, object> factory) :
+        Func<IDependencyContainer, object?> factory) :
         IDisposable
     {
         /// <summary>
@@ -26,7 +26,7 @@ namespace Chopsticks.Dependencies.Resolutions
         /// <summary>
         /// The factory that provides implementations for resolution.
         /// </summary>
-        protected Func<IDependencyContainer, object>? Factory { get; set; } = factory;
+        protected Func<IDependencyContainer, object?>? Factory { get; set; } = factory;
 
 
         /// <summary>

--- a/Native/Dependencies/Resolutions/SingletonResolution.cs
+++ b/Native/Dependencies/Resolutions/SingletonResolution.cs
@@ -9,7 +9,7 @@ namespace Chopsticks.Dependencies.Resolutions
     /// of <see cref="DependencyLifetime.Singleton"/>.
     /// </remarks>
     public class SingletonResolution(Type contract,
-        Func<IDependencyContainer, object> factory) :
+        Func<IDependencyContainer, object?> factory) :
         DependencyResolution(contract, factory)
     {
         private object? _instance;

--- a/Native/Dependencies/Resolutions/TransientResolution.cs
+++ b/Native/Dependencies/Resolutions/TransientResolution.cs
@@ -9,7 +9,7 @@ namespace Chopsticks.Dependencies.Resolutions
     /// of <see cref="DependencyLifetime.Transient"/>.
     /// </remarks>
     public class TransientResolution(Type contract,
-        Func<IDependencyContainer, object> factory) :
+        Func<IDependencyContainer, object?> factory) :
         DependencyResolution(contract, factory)
     {
         /// <inheritdoc/>

--- a/Native/Dependencies/Tests/DependencyContainerTests/Resolve.cs
+++ b/Native/Dependencies/Tests/DependencyContainerTests/Resolve.cs
@@ -1,7 +1,6 @@
 ﻿using Chopsticks.Dependencies.Containers;
 using Chopsticks.Dependencies.Resolutions;
 using NSubstitute;
-using System.ComponentModel;
 
 namespace DependencyContainerTests;
 

--- a/Native/Dependencies/Tests/IDependencyContainerExtensionsTests/AssertiveResolve.cs
+++ b/Native/Dependencies/Tests/IDependencyContainerExtensionsTests/AssertiveResolve.cs
@@ -1,0 +1,154 @@
+using Chopsticks.Dependencies;
+using Chopsticks.Dependencies.Containers;
+using Chopsticks.Dependencies.Exceptions;
+using NSubstitute;
+
+namespace IDependencyContainerExtensionsTests;
+
+public class AssertiveResolve
+{
+    public static class Mock
+    {
+        public static string RandomString => Guid.NewGuid().ToString();
+
+        public interface IContract { }
+    }
+
+
+    [Test]
+    public void AssertiveResolve_GenericNullResolvable_ThrowsWithErrorMessage()
+    {
+        // Set up
+        Mock.IContract? expectedImplementation = null;
+        var exceptionMessage = Mock.RandomString;
+        var isResolved = true;
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.Resolve(typeof(Mock.IContract), out _).Returns(x =>
+        {
+            x[1] = expectedImplementation;
+            return isResolved;
+        });
+
+        // Act & Assert
+        var exception = Assert.Throws<MissingDependencyException>(
+            () => container.AssertiveResolve<Mock.IContract>(exceptionMessage));
+
+        container.Received(1).Resolve(typeof(Mock.IContract), out _);
+        Assert.That(exception!.Message, Is.EqualTo(exceptionMessage));
+    }
+
+    [Test]
+    public void AssertiveResolve_GenericResolvable_EnforcesGenericTyping()
+    {
+        // Set up
+        var expectedImplementation = Substitute.For<Mock.IContract>();
+        var isResolved = true;
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.Resolve(typeof(Mock.IContract), out _).Returns(x =>
+        {
+            x[1] = expectedImplementation;
+            return isResolved;
+        });
+
+        // Act
+        var implementation = container.AssertiveResolve<Mock.IContract>();
+
+        // Assert
+        container.Received(1).Resolve(typeof(Mock.IContract), out _);
+        Assert.That(implementation, Is.EqualTo(expectedImplementation));
+    }
+
+    [Test]
+    public void AssertiveResolve_GenericUnresolvable_ThrowsWithErrorMessage()
+    {
+        // Set up
+        var expectedImplementation = Substitute.For<Mock.IContract>();
+        var exceptionMessage = Mock.RandomString;
+        var isResolved = false;
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.Resolve(typeof(Mock.IContract), out _).Returns(x =>
+        {
+            x[1] = expectedImplementation;
+            return isResolved;
+        });
+
+        // Act & Assert
+        var exception = Assert.Throws<MissingDependencyException>(
+            () => container.AssertiveResolve<Mock.IContract>(exceptionMessage));
+
+        container.Received(1).Resolve(typeof(Mock.IContract), out _);
+        Assert.That(exception!.Message, Is.EqualTo(exceptionMessage));
+    }
+
+
+    [Test]
+    public void AssertiveResolve_NonGenericNullResolvable_ThrowsWithErrorMessage()
+    {
+        // Set up
+        Mock.IContract? expectedImplementation = null;
+        var exceptionMessage = Mock.RandomString;
+        var isResolved = true;
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.Resolve(typeof(Mock.IContract), out _).Returns(x =>
+        {
+            x[1] = expectedImplementation;
+            return isResolved;
+        });
+
+        // Act & Assert
+        var exception = Assert.Throws<MissingDependencyException>(
+            () => container.AssertiveResolve(typeof(Mock.IContract), exceptionMessage));
+
+        container.Received(1).Resolve(typeof(Mock.IContract), out _);
+        Assert.That(exception!.Message, Is.EqualTo(exceptionMessage));
+    }
+
+    [Test]
+    public void AssertiveResolve_NonGenericResolvable_EnforcesGenericTyping()
+    {
+        // Set up
+        var expectedImplementation = Substitute.For<Mock.IContract>();
+        var isResolved = true;
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.Resolve(typeof(Mock.IContract), out _).Returns(x =>
+        {
+            x[1] = expectedImplementation;
+            return isResolved;
+        });
+
+        // Act
+        var implementation = container.AssertiveResolve(typeof(Mock.IContract));
+
+        // Assert
+        container.Received(1).Resolve(typeof(Mock.IContract), out _);
+        Assert.That(implementation, Is.EqualTo(expectedImplementation));
+    }
+
+    [Test]
+    public void AssertiveResolve_NonGenericUnresolvable_ThrowsWithErrorMessage()
+    {
+        // Set up
+        var expectedImplementation = Substitute.For<Mock.IContract>();
+        var exceptionMessage = Mock.RandomString;
+        var isResolved = false;
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.Resolve(typeof(Mock.IContract), out _).Returns(x =>
+        {
+            x[1] = expectedImplementation;
+            return isResolved;
+        });
+
+        // Act & Assert
+        var exception = Assert.Throws<MissingDependencyException>(
+            () => container.AssertiveResolve(typeof(Mock.IContract), exceptionMessage));
+
+        container.Received(1).Resolve(typeof(Mock.IContract), out _);
+        Assert.That(exception!.Message, Is.EqualTo(exceptionMessage));
+    }
+}

--- a/Native/Dependencies/Tests/IDependencyContainerExtensionsTests/Register.cs
+++ b/Native/Dependencies/Tests/IDependencyContainerExtensionsTests/Register.cs
@@ -1,0 +1,160 @@
+using Chopsticks.Dependencies;
+using Chopsticks.Dependencies.Containers;
+using Chopsticks.Dependencies.Resolutions;
+using NSubstitute;
+
+namespace IDependencyContainerExtensionsTests;
+
+public class Register
+{
+    public static class Mock
+    {
+        public static DependencyLifetime RandomLifetime => 
+            (DependencyLifetime)Random.Shared.Next(3);
+
+        public interface IContract { }
+
+        public class DependencyContainer : IDependencyContainer
+        {
+            public (DependencySpecification Spec, DependencyRegistration Registration) CallResults 
+            { get; set; }
+
+            bool IDependencyContainer.InheritParentDependencies
+            { 
+                get => throw new NotImplementedException(); 
+                set => throw new NotImplementedException();
+            }
+            IDependencyResolutionProvider? IDependencyContainer.Parent 
+            { 
+                get => throw new NotImplementedException(); 
+                set => throw new NotImplementedException(); 
+            }
+
+            IDependencyContainer IDependencyContainer.Deregister(
+                DependencyRegistration registration)
+            {
+                throw new NotImplementedException();
+            }
+
+            IDependencyContainer IDependencyContainer.Register(
+                DependencySpecification specification, 
+                out DependencyRegistration registration)
+            {
+                registration = new()
+                { 
+                    Contract = specification.Contract 
+                };
+                CallResults = (specification, registration);
+
+                return this;
+            }
+
+            bool IDependencyContainer.Resolve(Type contract, out object? implementation)
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerable<object> IDependencyContainer.ResolveAll(Type contract)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+
+
+    [Test]
+    public void Register_ForDependencyFactoryWithOut_CallsWithSpecAndPropagatesOut()
+    {
+        // Set up
+        var lifetime = Mock.RandomLifetime;
+        var container = new Mock.DependencyContainer();
+        var factoryResult = Substitute.For<Mock.IContract>();
+        Mock.IContract Factory(IDependencyContainer d) => factoryResult;
+
+        // Act
+        container.Register(Factory, out var registration, lifetime);
+
+        // Assert
+        Assert.That(container.CallResults.Spec.Contract, Is.EqualTo(typeof(Mock.IContract)));
+        Assert.That(container.CallResults.Spec.Lifetime, Is.EqualTo(lifetime));
+        Assert.That(container.CallResults.Spec.ImplementationFactory(container),
+            Is.EqualTo(factoryResult));
+
+        Assert.That(registration, Is.EqualTo(container.CallResults.Registration));
+    }
+
+    [Test]
+    public void Register_ForDependencyFactoryWithoutOut_CallsWithSpecAndIgnoresOut()
+    {
+        // Set up
+        var lifetime = Mock.RandomLifetime;
+        var container = new Mock.DependencyContainer();
+        var factoryResult = Substitute.For<Mock.IContract>();
+        Mock.IContract Factory(IDependencyContainer d) => factoryResult;
+
+        // Act
+        container.Register(Factory, lifetime);
+
+        // Assert
+        Assert.That(container.CallResults.Spec.Contract, Is.EqualTo(typeof(Mock.IContract)));
+        Assert.That(container.CallResults.Spec.Lifetime, Is.EqualTo(lifetime));
+        Assert.That(container.CallResults.Spec.ImplementationFactory(container),
+            Is.EqualTo(factoryResult));
+    }
+
+    [Test]
+    public void Register_ForDependencyInstanceWithOut_CallsWithSpecAndPropagatesOut()
+    {
+        // Set up
+        var lifetime = Mock.RandomLifetime;
+        var container = new Mock.DependencyContainer();
+        var dependency = Substitute.For<Mock.IContract>();
+
+        // Act
+        container.Register(dependency, out var registration);
+
+        // Assert
+        Assert.That(container.CallResults.Spec.Contract, Is.EqualTo(typeof(Mock.IContract)));
+        Assert.That(container.CallResults.Spec.Lifetime, Is.EqualTo(DependencyLifetime.Singleton));
+        Assert.That(container.CallResults.Spec.ImplementationFactory(container),
+            Is.EqualTo(dependency));
+
+        Assert.That(registration, Is.EqualTo(container.CallResults.Registration));
+    }
+
+    [Test]
+    public void Register_ForDependencyInstanceWithoutOut_CallsWithSpecAndIgnoresOut()
+    {
+        // Set up
+        var lifetime = Mock.RandomLifetime;
+        var container = new Mock.DependencyContainer();
+        var dependency = Substitute.For<Mock.IContract>();
+
+        // Act
+        container.Register(dependency);
+
+        // Assert
+        Assert.That(container.CallResults.Spec.Contract, Is.EqualTo(typeof(Mock.IContract)));
+        Assert.That(container.CallResults.Spec.Lifetime, Is.EqualTo(DependencyLifetime.Singleton));
+        Assert.That(container.CallResults.Spec.ImplementationFactory(container),
+            Is.EqualTo(dependency));
+    }
+
+    [Test]
+    public void Register_SpecificationOnly_CallsAndIgnoresOut()
+    {
+        // Set up
+        var container = Substitute.For<IDependencyContainer>();
+        var spec = new DependencySpecification()
+        {
+            Contract = typeof(Mock.IContract),
+            ImplementationFactory = _ => Substitute.For<Mock.IContract>()
+        };
+
+        // Act
+        container.Register(spec);
+
+        // Assert
+        container.Received().Register(spec, out _);
+    }
+}

--- a/Native/Dependencies/Tests/IDependencyContainerExtensionsTests/Resolve.cs
+++ b/Native/Dependencies/Tests/IDependencyContainerExtensionsTests/Resolve.cs
@@ -1,0 +1,59 @@
+using Chopsticks.Dependencies.Containers;
+using NSubstitute;
+
+namespace IDependencyContainerExtensionsTests;
+
+public class Resolve
+{
+    public static class Mock
+    {
+        public interface IContract { }
+    }
+
+
+    [Test]
+    public void Resolve_GenericCall_EnforcesGenericTyping()
+    {
+        // Set up
+        var expectedImplementation = Substitute.For<Mock.IContract>();
+        var isResolved = true;
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.Resolve(typeof(Mock.IContract), out _).Returns(x =>
+        {
+            x[1] = expectedImplementation;
+            return isResolved;
+        });
+
+        // Act
+        bool wasResolved = container.Resolve<Mock.IContract>(out var implementation);
+
+        // Assert
+        container.Received(1).Resolve(typeof(Mock.IContract), out _);
+        Assert.That(implementation, Is.EqualTo(expectedImplementation));
+        Assert.That(wasResolved, Is.EqualTo(isResolved));
+    }
+
+    [Test]
+    public void Resolve_UnknownDependency_False()
+    {
+        // Set up
+        Mock.IContract? expectedImplementation = null;
+        var isResolved = false;
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.Resolve(typeof(Mock.IContract), out _).Returns(x =>
+        {
+            x[1] = expectedImplementation;
+            return isResolved;
+        });
+
+        // Act
+        bool wasResolved = container.Resolve<Mock.IContract>(out var implementation);
+
+        // Assert
+        container.Received(1).Resolve(typeof(Mock.IContract), out _);
+        Assert.That(implementation, Is.EqualTo(expectedImplementation));
+        Assert.That(wasResolved, Is.EqualTo(isResolved));
+    }
+}

--- a/Native/Dependencies/Tests/IDependencyContainerExtensionsTests/ResolveAll.cs
+++ b/Native/Dependencies/Tests/IDependencyContainerExtensionsTests/ResolveAll.cs
@@ -1,0 +1,35 @@
+using Chopsticks.Dependencies.Containers;
+using NSubstitute;
+
+namespace IDependencyContainerExtensionsTests;
+
+public class ResolveAll
+{
+    public static class Mock
+    {
+        public interface IContract { }
+    }
+
+
+    [Test]
+    public void ResolveAll_GenericCall_EnforcesGenericTyping()
+    {
+        // Set up
+        var implementationA = Substitute.For<Mock.IContract>();
+        var implementationB = Substitute.For<Mock.IContract>();
+        IEnumerable<object> expectedImplementations = [
+            implementationA,
+            implementationB
+            ];
+
+        var container = Substitute.For<IDependencyContainer>();
+        container.ResolveAll(typeof(Mock.IContract)).Returns(expectedImplementations);
+
+        // Act
+        var implementations = container.ResolveAll<Mock.IContract>().ToArray();
+
+        // Assert
+        container.Received(1).ResolveAll(typeof(Mock.IContract));
+        Assert.That(implementations, Is.EquivalentTo(expectedImplementations));
+    }
+}

--- a/Native/Dependencies/Tests/Tests.csproj
+++ b/Native/Dependencies/Tests/Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RootNamespace></RootNamespace>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
### What Changed?
- Implemented IDependencyContainer extensions and their tests.
- Enabled implementation factories to return null.
### Why It Changed
- To simplify use of DependencyContainers.
- To Support more direct handling of implementation factory outputs with typing constraints that can be enforced per the new extension methods. This also enables developers to have a gray area of dependency support, where a dependency can be known to exist (it is resolvable) but resolving provides null, which indicates an incomplete resolution.
### How to Test
Verify unit tests pass.