### PR TITLE
Deploy Folder Metas

### DIFF
--- a/.github/workflows/publish-dependencies-package.yml
+++ b/.github/workflows/publish-dependencies-package.yml
@@ -56,6 +56,9 @@ jobs:
           mkdir -p $TEMP_DEPLOYMENT_DIR/Plugins/
           cp Unity/com.chopsticks.dependencies/package.json $TEMP_DEPLOYMENT_DIR/
           cp Unity/com.chopsticks.dependencies/package.json.meta $TEMP_DEPLOYMENT_DIR/
+          cp Unity/com.chopsticks.dependencies/Editor.meta $TEMP_DEPLOYMENT_DIR/
+          cp Unity/com.chopsticks.dependencies/Runtime.meta $TEMP_DEPLOYMENT_DIR/
+          cp Unity/com.chopsticks.dependencies/Plugins.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/* $TEMP_DEPLOYMENT_DIR/Editor/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/* $TEMP_DEPLOYMENT_DIR/Runtime/
           cp -r Unity/com.chopsticks.dependencies/Assets/Plugins/* $TEMP_DEPLOYMENT_DIR/Plugins/

--- a/Unity/com.chopsticks.dependencies/package.json
+++ b/Unity/com.chopsticks.dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.chopsticks.dependencies",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "displayName": "Chopsticks Dependencies",
   "description": "Provides dependency injection functionality for Unity.",
   "unity": "2023.2"


### PR DESCRIPTION
### What Changed?
- Ensured folder metas are included in the deployment.
### Why It Changed
- To enable consuming Unity projects to use the package code.
### How to Test
- No testing required.