### PR TITLE
Transfer Folder Metas

### DIFF
--- a/.github/workflows/publish-dependencies-package.yml
+++ b/.github/workflows/publish-dependencies-package.yml
@@ -58,7 +58,7 @@ jobs:
           cp Unity/com.chopsticks.dependencies/package.json.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/* $TEMP_DEPLOYMENT_DIR/Editor/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Editor.meta $TEMP_DEPLOYMENT_DIR/
-          cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/* $TEMP_DEPLOYMENT_DIR/Runtime/.meta
+          cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/* $TEMP_DEPLOYMENT_DIR/Runtime/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Plugins/* $TEMP_DEPLOYMENT_DIR/Plugins/
           cp -r Unity/com.chopsticks.dependencies/Assets/Plugins.meta $TEMP_DEPLOYMENT_DIR/

--- a/.github/workflows/publish-dependencies-package.yml
+++ b/.github/workflows/publish-dependencies-package.yml
@@ -56,12 +56,12 @@ jobs:
           mkdir -p $TEMP_DEPLOYMENT_DIR/Plugins/
           cp Unity/com.chopsticks.dependencies/package.json $TEMP_DEPLOYMENT_DIR/
           cp Unity/com.chopsticks.dependencies/package.json.meta $TEMP_DEPLOYMENT_DIR/
-          cp Unity/com.chopsticks.dependencies/Editor.meta $TEMP_DEPLOYMENT_DIR/
-          cp Unity/com.chopsticks.dependencies/Runtime.meta $TEMP_DEPLOYMENT_DIR/
-          cp Unity/com.chopsticks.dependencies/Plugins.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/* $TEMP_DEPLOYMENT_DIR/Editor/
-          cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/* $TEMP_DEPLOYMENT_DIR/Runtime/
+          cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Editor.meta $TEMP_DEPLOYMENT_DIR/
+          cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/* $TEMP_DEPLOYMENT_DIR/Runtime/.meta
+          cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Plugins/* $TEMP_DEPLOYMENT_DIR/Plugins/
+          cp -r Unity/com.chopsticks.dependencies/Assets/Plugins.meta $TEMP_DEPLOYMENT_DIR/
           
           if git ls-remote --heads origin | grep -q "refs/heads/$PACKAGE_BRANCH"; then
             echo "Branch $PACKAGE_BRANCH already exists. Checking it out."

--- a/.github/workflows/publish-dependencies-package.yml
+++ b/.github/workflows/publish-dependencies-package.yml
@@ -57,11 +57,11 @@ jobs:
           cp Unity/com.chopsticks.dependencies/package.json $TEMP_DEPLOYMENT_DIR/
           cp Unity/com.chopsticks.dependencies/package.json.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/* $TEMP_DEPLOYMENT_DIR/Editor/
-          cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Editor.meta $TEMP_DEPLOYMENT_DIR/
+          cp Unity/com.chopsticks.dependencies/Assets/Scripts/Editor.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/* $TEMP_DEPLOYMENT_DIR/Runtime/
-          cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime.meta $TEMP_DEPLOYMENT_DIR/
+          cp Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Plugins/* $TEMP_DEPLOYMENT_DIR/Plugins/
-          cp -r Unity/com.chopsticks.dependencies/Assets/Plugins.meta $TEMP_DEPLOYMENT_DIR/
+          cp Unity/com.chopsticks.dependencies/Assets/Plugins.meta $TEMP_DEPLOYMENT_DIR/
           
           if git ls-remote --heads origin | grep -q "refs/heads/$PACKAGE_BRANCH"; then
             echo "Branch $PACKAGE_BRANCH already exists. Checking it out."


### PR DESCRIPTION
### What Changed?
- Transfer folder metas instead of assuming they existed in-place.
### Why It Changed
- To properly deploy with the folder metas.
### How to Test
- Verified through deployment.