### PR TITLE
Add Simple Container Retrieval

### DIFF
--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/IUnityContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/IUnityContainerService.cs
@@ -58,6 +58,20 @@ namespace Chopsticks.Dependencies.Services
             ContainerRetrievalSetting setting, bool includeSelf,
             Transform unityContained, TOverrideContainer overrideContainer)
             where TOverrideContainer : IUnityContainer<TNativeContainer>;
+
+        /// <summary>
+        /// Provides a dependency container from the parent hierarchy of the 
+        /// provided contained Unity transform.
+        /// </summary>
+        /// <param name="includeSelf">Whether the provided Unity container considers 
+        /// itself to be part of the hierarchy to be searched.</param>
+        /// <param name="fallbackToGlobal">Whether the global container will be 
+        /// provided if there is no other container in the hierarchy.</param>
+        /// <param name="unityContained">The contained Unity transform from which 
+        /// retrieval will start.</param>
+        /// <returns>A container retrieved, or null if no such container could be found.</returns>
+        TNativeContainer GetContainerFromHierarchy(Transform unityContained,
+            bool includeSelf = true, bool fallbackToGlobal = true);
     }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/UnityContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/UnityContainerService.cs
@@ -97,16 +97,22 @@ namespace Chopsticks.Dependencies.Services
                                         $"{setting} is not supported."),
             };
 
+        /// <inheritdoc/>
+        public virtual TNativeContainer GetContainerFromHierarchy(Transform unityContained,
+            bool includeSelf = true, bool fallbackToGlobal = true) =>
+                FindContainerInHierarchy(includeSelf ?
+                    unityContained : unityContained.parent, fallbackToGlobal);
+
 
         private TNativeContainer FindContainerInHierarchy(
-            Transform transform, bool defaultToGlobal)
+            Transform transform, bool fallbackToGlobal)
         {
             var container = transform == null ? null :
                     transform.GetComponentInParent<IUnityContainer<TNativeContainer>>();
 
             if (container == null)
             {
-                if (defaultToGlobal)
+                if (fallbackToGlobal)
                     return _globalContainer;
                 return default;
             }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyExtensionsTests/Mocks/MockRegistrationContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyExtensionsTests/Mocks/MockRegistrationContainerService.cs
@@ -22,5 +22,9 @@ namespace IUnityDependencyExtensionsTests.Mocks
             TOverrideContainer overrideContainer)
             where TOverrideContainer : IUnityContainer<MockRegistrationDependencyContainer> => 
                 Sub.GetContainer(setting, includeSelf, unityContained, overrideContainer);
+
+        public MockRegistrationDependencyContainer GetContainerFromHierarchy(
+            Transform unityContained, bool includeSelf = true, bool fallbackToGlobal = true) => 
+            Sub.GetContainerFromHierarchy(unityContained, includeSelf, fallbackToGlobal);
     }
 }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainerFromHierarchy.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainerFromHierarchy.cs
@@ -1,0 +1,158 @@
+﻿using Chopsticks.Dependencies.Containers;
+using NUnit.Framework;
+using UnityEngine;
+
+using ContainerService = Chopsticks.Dependencies.Services.UnityContainerService<
+    Chopsticks.Dependencies.Containers.DependencyContainer,
+    Chopsticks.Dependencies.Factories.DefaultDependencyContainerFactory,
+    Chopsticks.Dependencies.Containers.DependencyContainerDefinition>;
+
+namespace UnityContainerServiceTests
+{
+    public class GetContainerFromHierarchy
+    {
+        public class SetUp
+        {
+            public static ContainerService SelfAsContainerWithParent(
+                out MonoContainer childContainer, out MonoContainer parentContainer)
+            {
+                var service = new ContainerService();
+
+                var parentGameObject = new GameObject("Parent Object");
+                var gameObject = new GameObject("Test Object");
+                gameObject.transform.parent = parentGameObject.transform;
+                gameObject.SetActive(false);
+
+                childContainer = gameObject.AddComponent<MonoContainer>();
+                parentContainer = parentGameObject.AddComponent<MonoContainer>();
+
+                gameObject.SetActive(true);
+
+                return service;
+            }
+
+            public static ContainerService SelfAsContainer(
+                out MonoContainer container)
+            {
+                var service = new ContainerService();
+
+                var gameObject = new GameObject("Test Object");
+
+                container = gameObject.AddComponent<MonoContainer>();
+
+                return service;
+            }
+            public static ContainerService SelfNotAsContainerWithParent(
+                out GameObject gameObject, out MonoContainer parentContainer)
+            {
+                var service = new ContainerService();
+
+                var parentGameObject = new GameObject("Parent Object");
+                gameObject = new GameObject("Test Object");
+                gameObject.transform.parent = parentGameObject.transform;
+                gameObject.SetActive(false);
+
+                parentContainer = parentGameObject.AddComponent<MonoContainer>();
+
+                gameObject.SetActive(true);
+
+                return service;
+            }
+        }
+
+
+        [Test]
+        [TestCase(true, true)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(false, false)]
+        public void GetContainerFromHierarchy_SelfAsContainerWithoutParent_ProvidesPerSettings(
+            bool includeSelf, bool fallbackToGlobal)
+        {
+            // Set up
+            var service = SetUp.SelfAsContainer(out var container);
+
+            // Act
+            var serviceContainer = service.GetContainerFromHierarchy(container.transform,
+                includeSelf, fallbackToGlobal);
+
+            // Assert
+            if (!includeSelf && fallbackToGlobal)
+                Assert.That(serviceContainer, Is.EqualTo(ContainerService.GlobalContainer));
+            else if (!includeSelf && !fallbackToGlobal)
+                Assert.That(serviceContainer, Is.Null);
+            else if (includeSelf)
+                Assert.That(serviceContainer, Is.EqualTo(
+                    (container as IUnityContainer<DependencyContainer>).NativeContainer));
+        }
+
+        [Test]
+        [TestCase(true, true)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(false, false)]
+        public void GetContainerFromHierarchy_SelfAsContainerWithParent_ProvidesPerSettings(
+            bool includeSelf, bool fallbackToGlobal)
+        {
+            // Set up
+            var service = SetUp.SelfAsContainerWithParent(out var child, out var parent);
+
+            // Act
+            var serviceContainer = service.GetContainerFromHierarchy(child.transform,
+                includeSelf, fallbackToGlobal);
+
+            // Assert
+            if (!includeSelf)
+                Assert.That(serviceContainer, Is.EqualTo(
+                    (parent as IUnityContainer<DependencyContainer>).NativeContainer));
+            else
+                Assert.That(serviceContainer, Is.EqualTo(
+                    (child as IUnityContainer<DependencyContainer>).NativeContainer));
+        }
+
+        [Test]
+        [TestCase(true, true)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(false, false)]
+        public void GetContainerFromHierarchy_SelfNotAsContainerWithoutParent_ProvidesPerSettings(
+            bool includeSelf, bool fallbackToGlobal)
+        {
+            // Set up
+            var service = new ContainerService();
+
+            var gameObject = new GameObject("Test Object");
+            gameObject.SetActive(false);
+
+            // Act
+            var serviceContainer = service.GetContainerFromHierarchy(gameObject.transform,
+                includeSelf, fallbackToGlobal);
+
+            // Assert
+            if (fallbackToGlobal)
+                Assert.That(serviceContainer, Is.EqualTo(ContainerService.GlobalContainer));
+            else
+                Assert.That(serviceContainer, Is.Null);
+        }
+
+        [Test]
+        [TestCase(true, true)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(false, false)]
+        public void GetContainerFromHierarchy_SelfNotAsContainerWithParent_ProvidesPerSettings(
+            bool includeSelf, bool fallbackToGlobal)
+        {
+            // Set up
+            var service = SetUp.SelfNotAsContainerWithParent(out var child, out var parent);
+
+            // Act
+            var serviceContainer = service.GetContainerFromHierarchy(child.transform,
+                includeSelf, fallbackToGlobal);
+
+            // Assert
+            Assert.That(serviceContainer, Is.EqualTo(
+                (parent as IUnityContainer<DependencyContainer>).NativeContainer));
+        }
+    }
+}

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainerFromHierarchy.cs.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainerFromHierarchy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 41bdbafb8b6abb947aba3dbc632058db


### PR DESCRIPTION
### What Changed?
- Added a GetContainerFromHierarchy method for UnityContainerService.
### Why It Changed
- To simplify the retrieval of containers for GameObjects, in most dev-driven use cases.
### How to Test
- Verify the project tests pass.