### PR TITLE
Fix Missing Dependency Exception Log

### DIFF
--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/BaseMonoDependent.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/BaseMonoDependent.cs
@@ -64,7 +64,7 @@ namespace Chopsticks.Dependencies
 
         /// <inheritdoc cref="IUnityContainedExtensions
         /// .AssertiveResolve{TNativeContainer, TContract}(IUnityContained{TNativeContainer}, string)"/>
-        protected TContract AssertiveResolve<TContract>(string customErrorMessage = "") => 
+        protected TContract AssertiveResolve<TContract>(string customErrorMessage = null) => 
             this.AssertiveResolve<TNativeContainer, TContract>(customErrorMessage);
 
         /// <inheritdoc cref="IUnityContainedExtensions

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IUnityContainedExtensions.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IUnityContainedExtensions.cs
@@ -13,9 +13,9 @@ namespace Chopsticks.Dependencies.Contained
         /// <inheritdoc cref="IDependencyContainerExtensions
         /// .AssertiveResolve{TContract}(IDependencyContainer, string?)"/>
         public static TContract AssertiveResolve<TNativeContainer, TContract>(
-            this IUnityContained<TNativeContainer> contained, string customErrorMessage = "")
-            where TNativeContainer : IDependencyContainer, IDependencyResolutionProvider, IDisposable => 
-            contained.Container.AssertiveResolve<TContract>(customErrorMessage);
+            this IUnityContained<TNativeContainer> contained, string customErrorMessage = null)
+            where TNativeContainer : IDependencyContainer, IDependencyResolutionProvider, IDisposable =>
+                contained.Container.AssertiveResolve<TContract>(customErrorMessage);
 
         /// <inheritdoc cref="IDependencyContainerExtensions
         /// .Resolve{TContract}(IDependencyContainer, out TContract)"/>
@@ -23,13 +23,13 @@ namespace Chopsticks.Dependencies.Contained
             this IUnityContained<TNativeContainer> contained,
             out TContract implementation)
             where TNativeContainer : IDependencyContainer, IDependencyResolutionProvider, IDisposable => 
-            contained.Container.Resolve(out implementation);
+                contained.Container.Resolve(out implementation);
 
         /// <inheritdoc cref="IDependencyContainerExtensions
         /// .ResolveAll{TContract}(IDependencyContainer)"/>
         public static IEnumerable<TContract> ResolveAll<TNativeContainer, TContract>(
             this IUnityContained<TNativeContainer> contained)
             where TNativeContainer : IDependencyContainer, IDependencyResolutionProvider, IDisposable =>
-            contained.Container.ResolveAll<TContract>();
+                contained.Container.ResolveAll<TContract>();
     }
 }


### PR DESCRIPTION
### What Changed?
- Updated resolution call wrappers to use the expected 'null' as the default parameter for custom error messages.
### Why It Changed
- This ensures that using the default calls will result in the default error message being attribute to the exception, so the message is then displayed in the console as expected.
### How to Test
**Verify Exception Message**
1. Open the SingleConfiguredApp scene.
2. Select Configuration -> ExampleSystem.
3. Disable all systems.
4. Play the scene.
5. Click the cube to trigger the attempted resolution of an IExampleSystem.
6. Verify that the MissingDependencyException is logged to the console with a message detailing what dependency could not be resolved.