### PR TITLE
Clear Scene Between Tests

### DIFF
--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyExtensionsTests/SetContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyExtensionsTests/SetContainer.cs
@@ -10,6 +10,7 @@ using MonoContainerService = Chopsticks.Dependencies.Services.IUnityContainerSer
     MonoContainerTests.Mocks.MockDependencyContainer,
     MonoContainerTests.Mocks.MockDependencyContainer.Definition>;
 using IUnityDependencyExtensionsTests.Mocks;
+using UnityEngine.SceneManagement;
 
 namespace IUnityDependencyExtensionsTests
 {
@@ -37,6 +38,12 @@ namespace IUnityDependencyExtensionsTests
 
                 return unityDependency;
             }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyExtensionsTests/UpdateContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyExtensionsTests/UpdateContainer.cs
@@ -10,6 +10,7 @@ using MonoContainerService = Chopsticks.Dependencies.Services.IUnityContainerSer
     MonoContainerTests.Mocks.MockDependencyContainer,
     MonoContainerTests.Mocks.MockDependencyContainer.Definition>;
 using IUnityDependencyExtensionsTests.Mocks;
+using UnityEngine.SceneManagement;
 
 namespace IUnityDependencyExtensionsTests
 {
@@ -60,6 +61,12 @@ namespace IUnityDependencyExtensionsTests
 
                 return unityDependency;
             }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/FindContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/FindContainer.cs
@@ -5,12 +5,21 @@ using MonoContainerTests.Mocks;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace IUnityDependentExtensionsTests
 {
 
     public class FindContainer
     {
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
+        }
+
+
         [Test]
         public void FindContainer_StandardCall_ReturnsFromServiceGetContainer()
         {

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/SetContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/SetContainer.cs
@@ -10,6 +10,7 @@ using MonoContainerService = Chopsticks.Dependencies.Services.IUnityContainerSer
     MonoContainerTests.Mocks.MockDependencyContainer,
     MonoContainerTests.Mocks.MockDependencyContainer.Definition>;
 using IUnityDependentExtensionsTests.Mocks;
+using UnityEngine.SceneManagement;
 
 namespace IUnityDependentExtensionsTests
 {
@@ -37,6 +38,12 @@ namespace IUnityDependentExtensionsTests
 
                 return unityDependent;
             }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/UpdateContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/UpdateContainer.cs
@@ -10,6 +10,7 @@ using MonoContainerService = Chopsticks.Dependencies.Services.IUnityContainerSer
     MonoContainerTests.Mocks.MockDependencyContainer, 
     MonoContainerTests.Mocks.MockDependencyContainer.Definition>;
 using IUnityDependentExtensionsTests.Mocks;
+using UnityEngine.SceneManagement;
 
 namespace IUnityDependentExtensionsTests
 {
@@ -60,6 +61,12 @@ namespace IUnityDependentExtensionsTests
 
                 return unityDependency;
             }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/ContainerParentSetting.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/ContainerParentSetting.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 using NUnit.Framework;
 using TestHelpers;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using ParentSetting = Chopsticks.Dependencies.Containers.ContainerSetting;
 
@@ -39,6 +40,12 @@ namespace MonoContainerTests
 
                 return container;
             }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Deregister.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Deregister.cs
@@ -3,6 +3,7 @@ using MonoContainerTests.Mocks;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace MonoContainerTests
 {
@@ -11,6 +12,12 @@ namespace MonoContainerTests
         public static class Mock
         {
             public interface IContract { }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/InheritParentDependencies.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/InheritParentDependencies.cs
@@ -2,11 +2,19 @@
 using NUnit.Framework;
 using TestHelpers;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace MonoContainerTests
 {
     public class InheritParentDependencies
     {
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
+        }
+
+
         [Test]
         public void InheritParentDependencies_FalseThroughSerializedFieldOnAwake_Sets()
         {

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/OnDestroy.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/OnDestroy.cs
@@ -2,11 +2,19 @@
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace MonoContainerTests
 {
     public class OnDestroy
     {
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
+        }
+
+
         [Test]
         public void OnDestroy_ComponentDestruction_DisposesOfInternalContainer()
         {

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Register.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Register.cs
@@ -3,6 +3,7 @@ using MonoContainerTests.Mocks;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace MonoContainerTests
 {
@@ -11,6 +12,12 @@ namespace MonoContainerTests
         public static class Mock
         {
             public interface IContract { }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/RegisterNativeDependencies.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/RegisterNativeDependencies.cs
@@ -1,11 +1,19 @@
 ﻿using MonoContainerTests.Mocks;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace MonoContainerTests
 {
     public class RegisterNativeDependencies
     {
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
+        }
+
+
         [Test]
         public void RegisterNativeDependencies_OnAwake_WasCalled()
         {

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Resolve.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Resolve.cs
@@ -2,6 +2,7 @@
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace MonoContainerTests
 {
@@ -10,6 +11,12 @@ namespace MonoContainerTests
         public static class Mock
         {
             public interface IContract { }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/ResolveAll.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/ResolveAll.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace MonoContainerTests
 {
@@ -13,6 +14,13 @@ namespace MonoContainerTests
         {
             public interface IContract { }
         }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
+        }
+
 
         [Test]
         public void ResolveAll_StandardCall_ProvidesFromInternalContainer()

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/BuildContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/BuildContainer.cs
@@ -1,11 +1,19 @@
 ﻿using Chopsticks.Dependencies.Services;
 using MonoContainerTests.Mocks;
 using NUnit.Framework;
+using UnityEngine.SceneManagement;
 
 namespace UnityContainerServiceTests
 {
     public class BuildContainer
     {
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
+        }
+
+
         [Test]
         public void BuildContainer_WithDefinition_UsesFactoryWithDefintion()
         {

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/FindParentContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/FindParentContainer.cs
@@ -1,7 +1,7 @@
 ﻿using Chopsticks.Dependencies.Containers;
 using NUnit.Framework;
 using UnityEngine;
-
+using UnityEngine.SceneManagement;
 using ContainerService = Chopsticks.Dependencies.Services.UnityContainerService<
     Chopsticks.Dependencies.Containers.DependencyContainer,
     Chopsticks.Dependencies.Factories.DefaultDependencyContainerFactory,
@@ -43,6 +43,12 @@ namespace UnityContainerServiceTests
 
                 return service;
             }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainer.cs
@@ -1,7 +1,7 @@
 ﻿using Chopsticks.Dependencies.Containers;
 using NUnit.Framework;
 using UnityEngine;
-
+using UnityEngine.SceneManagement;
 using ContainerService = Chopsticks.Dependencies.Services.UnityContainerService<
     Chopsticks.Dependencies.Containers.DependencyContainer,
     Chopsticks.Dependencies.Factories.DefaultDependencyContainerFactory,
@@ -43,6 +43,12 @@ namespace UnityContainerServiceTests
 
                 return service;
             }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainerFromHierarchy.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainerFromHierarchy.cs
@@ -1,7 +1,7 @@
 ﻿using Chopsticks.Dependencies.Containers;
 using NUnit.Framework;
 using UnityEngine;
-
+using UnityEngine.SceneManagement;
 using ContainerService = Chopsticks.Dependencies.Services.UnityContainerService<
     Chopsticks.Dependencies.Containers.DependencyContainer,
     Chopsticks.Dependencies.Factories.DefaultDependencyContainerFactory,
@@ -58,6 +58,12 @@ namespace UnityContainerServiceTests
 
                 return service;
             }
+        }
+
+        [SetUp]
+        public void SetUpScene()
+        {
+            SceneManager.LoadScene("StandardTestScene");
         }
 
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Scenes.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 862de6676b14c4c418c5118e11c8838f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Scenes/StandardTestScene.unity
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Scenes/StandardTestScene.unity
@@ -1,0 +1,125 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots: []

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Scenes/StandardTestScene.unity.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Scenes/StandardTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0e83e60b6e0f80541852ed6b4186368c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### What Changed?
- Added a standard (empty) test scene.
- Ensured the standard test scene was loaded (non-additively) before each test that would rely on the scene.
### Why It Changed
- To ensure any alterations to the scene made during a previous test would not influence the current test.
### How to Test
- Verify the project tests pass.