### PR TITLE
Add Samples to Deployment

### DIFF
--- a/.github/workflows/publish-dependencies-package.yml
+++ b/.github/workflows/publish-dependencies-package.yml
@@ -54,12 +54,15 @@ jobs:
           mkdir -p $TEMP_DEPLOYMENT_DIR/Editor/
           mkdir -p $TEMP_DEPLOYMENT_DIR/Runtime/
           mkdir -p $TEMP_DEPLOYMENT_DIR/Plugins/
+          mkdir -p $TEMP_DEPLOYMENT_DIR/~Samples/
           cp Unity/com.chopsticks.dependencies/package.json $TEMP_DEPLOYMENT_DIR/
           cp Unity/com.chopsticks.dependencies/package.json.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/* $TEMP_DEPLOYMENT_DIR/Editor/
           cp Unity/com.chopsticks.dependencies/Assets/Scripts/Editor.meta $TEMP_DEPLOYMENT_DIR/
           cp -r Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/* $TEMP_DEPLOYMENT_DIR/Runtime/
           cp Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime.meta $TEMP_DEPLOYMENT_DIR/
+          cp -r Unity/com.chopsticks.dependencies/Assets/Samples/* $TEMP_DEPLOYMENT_DIR/~Samples/
+          cp Unity/com.chopsticks.dependencies/Assets/Samples.meta $TEMP_DEPLOYMENT_DIR/~Samples.meta
           cp -r Unity/com.chopsticks.dependencies/Assets/Plugins/* $TEMP_DEPLOYMENT_DIR/Plugins/
           cp Unity/com.chopsticks.dependencies/Assets/Plugins.meta $TEMP_DEPLOYMENT_DIR/
           

--- a/Unity/com.chopsticks.dependencies/package.json
+++ b/Unity/com.chopsticks.dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.chopsticks.dependencies",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "displayName": "Chopsticks Dependencies",
   "description": "Provides dependency injection functionality for Unity.",
   "unity": "2023.2"


### PR DESCRIPTION
### What Changed?
- Added the copying of the Samples folder to the ~Samples folder for a deployed package.
### Why It Changed
- To include the Samples in the deployed package, without them being evaluated by Unity after being imported.
### How to Test
- Verify that the deployed package has the ~Samples.