### PR TITLE
Add Example Test to Samples

### DIFF
--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Scripts/ExampleDependencies/ExampleSystem/Counting/CountingSystem.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Scripts/ExampleDependencies/ExampleSystem/Counting/CountingSystem.cs
@@ -14,13 +14,15 @@ namespace Chopsticks.Samples.ExampleDependencies.ExampleSystem.Counting
     public class CountingSystem : UnalterableCountingSystemSuperclass, IMonoDependency
     {
         /// <inheritdoc/>
-        public List<DependencyRegistration> Registrations { get; } = new();
+        List<DependencyRegistration> IUnityDependency<DependencyContainer, MonoContainerService>
+            .Registrations { get; } = new();
 
         /// <inheritdoc/>
-        public DependencyContainer Container { get; set; }
+        DependencyContainer IUnityContained<DependencyContainer>.Container { get; set; }
 
         /// <inheritdoc/>
-        public ContainerSetting ContainerSetting => ContainerSetting.HierarchyWithGlobal;
+        ContainerSetting IUnityContained<DependencyContainer>.ContainerSetting => 
+            ContainerSetting.HierarchyWithGlobal;
 
 
         /// <inheritdoc/>

--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Tests.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 91387b6f15e1f504bb480d816f42aa02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Tests/Runtime.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed7fddc179c90a243b053efd8b8d8374
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Tests/Runtime/ExampleConfiguredInputHandlerTests.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Tests/Runtime/ExampleConfiguredInputHandlerTests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46e367ae68826be41a9234568940f028
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Tests/Runtime/ExampleConfiguredInputHandlerTests/OnMouseUp.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Tests/Runtime/ExampleConfiguredInputHandlerTests/OnMouseUp.cs
@@ -1,0 +1,57 @@
+﻿using Chopsticks.Dependencies.Contained;
+using Chopsticks.Dependencies.Containers;
+using Chopsticks.Samples.ExampleDependencies.ExampleSystem;
+using Chopsticks.Samples.ExampleDependents.InputHandler;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace ExampleConfiguredInputHandlerTests
+{
+    /// <summary>
+    /// An example test class to verify <see cref="ConfiguredInputHandler.OnMouseUp"/>, 
+    /// showing how to leverage the dependency container to mock dependencies under test.
+    /// </summary>
+    public class OnMouseUp
+    {
+        /// <summary>
+        /// A test case that verifies that the <see cref="IExampleSystem"/> depended upon by 
+        /// <see cref="ConfiguredInputHandler"/> is used as expected upon 
+        /// <see cref="ConfiguredInputHandler.OnMouseUp"/>.
+        /// </summary>
+        [Test]
+        public void OnMouseUp_System_Performs()
+        {
+            // Set up - Define the dependent and set its dependencies as mocks.
+            // All implementations of IMonoDependency/IMonoDependent and 
+            // subclasses of MonoDependency/MonoDependent can be set up similarly.
+
+            // Create and set up mock dependencies.
+            var system = Substitute.For<IExampleSystem>();
+
+            // Create a container specific to the test conditions.
+            var container = new DependencyContainer();
+            container.Register(system);
+
+            // Create and set up the GameObject.
+            var gameObject = new GameObject();
+            gameObject.SetActive(false); // Disable to prevent unrelated functionality.
+
+            // Create the input handler and set its container to define its test state.
+            var inputHandler = gameObject.AddComponent<ConfiguredInputHandler>();
+            (inputHandler as IUnityContained<DependencyContainer>).Container = container;
+
+
+            // Act - Initiate the method under test.
+            inputHandler.OnMouseUp();
+
+
+            // Assert - Verify dependencies are used as expected.
+            system.Received(1).Perform();
+
+
+            // Tear down - Destroy the GameObject to clear for the next test.
+            Object.DestroyImmediate(gameObject);
+        }
+    }
+}

--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Tests/Runtime/ExampleConfiguredInputHandlerTests/OnMouseUp.cs.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Tests/Runtime/ExampleConfiguredInputHandlerTests/OnMouseUp.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b90ced5e3abed6142a020d1f5aa84fc4


### PR DESCRIPTION
### What Changed?
- Added an example test for ConfiguredInputHandler to Samples.
- Changed CountingSystem's implementation of IMonoDependency to use explicit properties for its interfaces.
### Why It Changed
- To show how substitution can work with the dependency injection system for more contained testing.
- To make CountingSystem's properties match the scope of implementation of MonoDependency.
### How to Test
**No testing required.**