### PR TITLE
Add Simplified RegisterAs

### DIFF
--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Scripts/ExampleDependencies/ExampleSystem/Counting/CountingSystem.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Scripts/ExampleDependencies/ExampleSystem/Counting/CountingSystem.cs
@@ -43,7 +43,7 @@ namespace Chopsticks.Samples.ExampleDependencies.ExampleSystem.Counting
         /// </summary>
         protected void PerformRegistration()
         {
-            this.RegisterAs<DependencyContainer, MonoContainerService, IExampleSystem>();
+            this.RegisterAs<IExampleSystem>();
         }
     }
 }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IMonoDependencyExtensions.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IMonoDependencyExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Chopsticks.Dependencies.Containers;
+using Chopsticks.Dependencies.Services;
+
+namespace Chopsticks.Dependencies.Contained
+{
+    /// <summary>
+    /// Provides extensions to Unity monodependency implementations.
+    /// </summary>
+    public static class IMonoDependencyExtensions
+    {
+        /// <summary>
+        /// Registers this dependency as the specified contract for its container.
+        /// </summary>
+        /// <typeparam name="TContract">The contract type that the dependency 
+        /// is being registered as.</typeparam>
+        /// <param name="dependency">This dependency that is being registered.</param>
+        public static DependencyRegistration RegisterAs<TContract>(
+            this IUnityDependency<DependencyContainer, MonoContainerService> dependency) => 
+            dependency.RegisterAs<DependencyContainer, MonoContainerService, TContract>();
+    }
+}

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IMonoDependencyExtensions.cs.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IMonoDependencyExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a65972c543bef104389f1e83a472b404


### PR DESCRIPTION
### What Changed?
- Added a convenience method for IMonoDependency, for RegisterAs.
- Updated the CountingSystem example implementation of IMonoDependency to use the new convenience method.
### Why It Changed
- To simplify use by IMonoDependency implementations, specifically to keep the implementor from having to consider the generics that are already hardcoded for IMonoDependency.
- To show usage of the new convenience method, as should be the common scenario when implementing IMonoDependency.
### How to Test
**Verify CountingSystem works with the new RegisterAs**
1. Open the SimpleConfiguredApp sample scene.
2. Select Configuration -> ExampleSystem in the hierarchy.
3. Ensure that the Counting System is the only IExampleSystem implementation enabled.
4. Play the scene.
5. Click the cube.
6. Verify that the CountingSystem is used as expected (outputting an incrementing count to the console for each click).