### PR TITLE
Provide Shared MonoContainer Service

### DIFF
--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Scripts/ExampleDependencies/ExampleSystem/Native/NativeSystemLocalContainerWrapper.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Scripts/ExampleDependencies/ExampleSystem/Native/NativeSystemLocalContainerWrapper.cs
@@ -20,12 +20,6 @@ namespace Chopsticks.Samples.ExampleDependencies.ExampleSystem.Native
         private DependencyRegistration _registration;
 
         /// <summary>
-        /// The specific instance of the container service that will enable retrieval 
-        /// of the local container.
-        /// </summary>
-        private MonoContainerService _containerService;
-
-        /// <summary>
         /// The last known local container.
         /// </summary>
         private DependencyContainer _container;
@@ -37,7 +31,7 @@ namespace Chopsticks.Samples.ExampleDependencies.ExampleSystem.Native
         /// </summary>
         public void OnEnable()
         {
-            _container = _containerService.GetContainerFromHierarchy(transform);
+            _container = MonoContainerService.Shared.GetContainerFromHierarchy(transform);
             _container.Register<IExampleSystem>(new NativeSystem(), out _registration);
         }
 
@@ -62,7 +56,7 @@ namespace Chopsticks.Samples.ExampleDependencies.ExampleSystem.Native
         {
             _container.Deregister(_registration);
 
-            _container = _containerService.GetContainerFromHierarchy(transform);
+            _container = MonoContainerService.Shared.GetContainerFromHierarchy(transform);
             _container.Register(new NativeSystem(), out _registration);
         }
     }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IUnityDependent.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IUnityDependent.cs
@@ -14,7 +14,7 @@ namespace Chopsticks.Dependencies.Contained
     /// provides Unity-specific services.</typeparam>
     public interface IUnityDependent<TNativeContainer, TUnityContainerService> : 
         IUnityContained<TNativeContainer>, 
-        IUnityContainerConsumer<TNativeContainer, TUnityContainerService>
+        IUnityContainerServiceProvider<TNativeContainer, TUnityContainerService>
         where TNativeContainer : IDependencyContainer, IDependencyResolutionProvider, IDisposable
         where TUnityContainerService : IUnityContainerService<TNativeContainer>, new()
     {

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/BaseMonoContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/BaseMonoContainer.cs
@@ -25,7 +25,7 @@ namespace Chopsticks.Dependencies.Containers
     public abstract class BaseMonoContainer<TNativeContainer, TNativeContainerFactory,
         TNativeContainerDefinition, TUnityContainerService> :
         BaseUnityContainer<TNativeContainer>, 
-        IUnityContainerConsumer<TNativeContainer, TUnityContainerService>
+        IUnityContainerServiceProvider<TNativeContainer, TUnityContainerService>
         where TNativeContainer : IDependencyContainer, IDependencyResolutionProvider, IDisposable
         where TNativeContainerFactory : IDependencyContainerFactory<TNativeContainer,
             TNativeContainerDefinition>, new()
@@ -36,7 +36,7 @@ namespace Chopsticks.Dependencies.Containers
         /// The Unity container service that provides Unity-specific services for containers.
         /// </summary>
         protected TUnityContainerService ContainerService =>
-            (this as IUnityContainerConsumer<TNativeContainer, TUnityContainerService>).Service;
+            (this as IUnityContainerServiceProvider<TNativeContainer, TUnityContainerService>).Service;
 
         /// <inheritdoc/>
         protected override TNativeContainer InternalContainer =>

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/IUnityContainerConsumer.cs.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/IUnityContainerConsumer.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: b73fc56c50e68914cb5524072f27128f

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/IUnityContainerServiceProvider.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/IUnityContainerServiceProvider.cs
@@ -1,25 +1,24 @@
-﻿using Chopsticks.Dependencies.Resolutions;
-using Chopsticks.Dependencies.Services;
+﻿using Chopsticks.Dependencies.Containers;
+using Chopsticks.Dependencies.Resolutions;
 using System;
 
-namespace Chopsticks.Dependencies.Containers
+namespace Chopsticks.Dependencies.Services
 {
     /// <summary>
-    /// Defines a Unity container consumer that is serviced 
-    /// by <see cref="IUnityContainerService{TNativeContainer}"/>.
+    /// Defines a <see cref="IUnityContainerService{TNativeContainer}"/> provider.
     /// </summary>
     /// <typeparam name="TNativeContainer">The type of the internal, non-Unity 
     /// dependency container that is consumed by the Unity contianer.</typeparam>
     /// <typeparam name="TUnityContainerService">The type of service provider 
     /// for working with Unity containers.</typeparam>
-    public interface IUnityContainerConsumer<TNativeContainer, TUnityContainerService>
+    public interface IUnityContainerServiceProvider<TNativeContainer, TUnityContainerService>
         where TNativeContainer : IDependencyContainer, IDependencyResolutionProvider, IDisposable
         where TUnityContainerService : IUnityContainerService<TNativeContainer>, new()
     {
         /// <summary>
-        /// The Unity service that provides container services for Unity container consumers.
+        /// The provided Unity container service.
         /// </summary>
-        TUnityContainerService Service => _unityContainerService;
-        private static readonly TUnityContainerService _unityContainerService = new();
+        TUnityContainerService Service => InternalService;
+        protected static TUnityContainerService InternalService { get; } = new();
     }
 }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/IUnityContainerServiceProvider.cs.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/IUnityContainerServiceProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 56d6d6ba57d1fbe4eb0e689de4c54d7a

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/MonoContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/MonoContainerService.cs
@@ -8,7 +8,15 @@ namespace Chopsticks.Dependencies.Services
     /// access to a global instance and strategies to work with other containers.
     /// </summary>
     public class MonoContainerService : UnityContainerService<
-        DependencyContainer, DefaultDependencyContainerFactory, DependencyContainerDefinition>
+        DependencyContainer, DefaultDependencyContainerFactory, DependencyContainerDefinition>,
+        IUnityContainerServiceProvider<DependencyContainer, MonoContainerService>
     {
+        /// <summary>
+        /// The service instance used across all standard <see cref="MonoDependency"/> 
+        /// and <see cref="MonoDependent"/> instances to integrate 
+        /// with <see cref="MonoContainer"/>s.
+        /// </summary>
+        public static MonoContainerService Shared =>
+            IUnityContainerServiceProvider<DependencyContainer, MonoContainerService>.InternalService;
     }
 }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/FindContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/FindContainer.cs
@@ -1,5 +1,6 @@
 ﻿using Chopsticks.Dependencies.Contained;
 using Chopsticks.Dependencies.Containers;
+using Chopsticks.Dependencies.Services;
 using IUnityDependentExtensionsTests.Mocks;
 using MonoContainerTests.Mocks;
 using NSubstitute;
@@ -25,7 +26,7 @@ namespace IUnityDependentExtensionsTests
         {
             // Set up
             var expectedContainer = Substitute.For<MockDependencyContainer>();
-            var mockService = (expectedContainer as IUnityContainerConsumer<MockDependencyContainer, 
+            var mockService = (expectedContainer as IUnityContainerServiceProvider<MockDependencyContainer, 
                 MockMonoContainerService>).Service.Sub;
             var unityDependent = Substitute.For<MockUnityDependent>();
             unityDependent.Container = null;

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Mocks/MockDependencyContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Mocks/MockDependencyContainer.cs
@@ -1,5 +1,6 @@
 ﻿using Chopsticks.Dependencies.Containers;
 using Chopsticks.Dependencies.Resolutions;
+using Chopsticks.Dependencies.Services;
 using System;
 using System.Collections.Generic;
 
@@ -7,7 +8,7 @@ namespace MonoContainerTests.Mocks
 {
     public abstract class MockDependencyContainer :
         IDependencyContainer, IDependencyResolutionProvider, IDisposable,
-        IUnityContainerConsumer<MockDependencyContainer, MockMonoContainerService>
+        IUnityContainerServiceProvider<MockDependencyContainer, MockMonoContainerService>
     {
         public class Definition { }
 


### PR DESCRIPTION
### What Changed?
- Refactored IUnityContainerConsumer to IUnityContainerServiceProvider.
- Provided access to a static (shared) instance of MonoContainerService.
- Updates example code to use the new shared instance.
### Why It Changed
- To emphasize how an implementation of IUnityContainerServiceProvider is providing a container service, even though generally to itself.
- To simplify use of MonoContainerService, and reduce memory overhead by consolidating standard use to a single shared instance.
- To show use of the new MonoContainerService.Shared.
### How to Test
**No testing required beyond the automated test suites.**