### PR TITLE
Add Initial Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,13 +17,6 @@ layout:
     visible: true
 ---
 
-# A General Introduction to Contextual Programming
-
-**First Edition - October 2024**\
-By Lucas Stertz
-
-
-
-## Overview
+# Overview
 
 These docs describe the expected use and capabilities of the SDKs included in Chopsticks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+---
+description: >-
+  The official documentation for the Chopsticks suite of SDKs.
+layout:
+  cover:
+    visible: false
+    size: full
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: false
+  pagination:
+    visible: true
+---
+
+# A General Introduction to Contextual Programming
+
+**First Edition - October 2024**\
+By Lucas Stertz
+
+
+
+## Overview
+
+These docs describe the expected use and capabilities of the SDKs included in Chopsticks.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,7 @@
+# Table of contents
+
+* [Chopsticks](README.md)
+
+## Dependencies
+
+* [Overview](dependencies/overview.md)

--- a/docs/dependencies/overview.md
+++ b/docs/dependencies/overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+The Dependencies SDK provides dependency injection services.


### PR DESCRIPTION
### What Changed?
- Added the initial docs to be used with the GitBook integration
### Why It Changed
- To have some files for GitBook documentation writing to start from.
### How to Test
**No testing required.**