### PR TITLE
Add Configuration to MonoContainer Editor

### DIFF
--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.cs
@@ -16,7 +16,6 @@ namespace Chopsticks.Dependencies.Editor
 
         private static readonly HashSet<string> ExcludedProperties = new()
         {
-            "m_Script",
             ContainerParentSetting,
             InheritParentDependencies,
             OverrideParent

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.cs
@@ -3,13 +3,28 @@ using UnityEngine.UIElements;
 using UnityEditor;
 using UnityEditor.UIElements;
 using Chopsticks.Dependencies.Containers;
+using System.Collections.Generic;
 
 namespace Chopsticks.Dependencies.Editor
 {
     [CustomEditor(typeof(BaseMonoContainer<,,,>), true)]
     public class BaseMonoContainerEditor : UnityEditor.Editor
     {
+        private const string ContainerParentSetting = "_containerParentSetting";
+        private const string InheritParentDependencies = "_inheritParentDependencies";
+        private const string OverrideParent = "_overrideParent";
+
+        private static readonly HashSet<string> ExcludedProperties = new()
+        {
+            "m_Script",
+            ContainerParentSetting,
+            InheritParentDependencies,
+            OverrideParent
+        };
+
+
         private VisualElement _root;
+        private VisualElement _configurationContainer;
         private PropertyField _parentSettingField;
         private PropertyField _inheritDependenciesField;
         private PropertyField _overrideParentField;
@@ -24,6 +39,7 @@ namespace Chopsticks.Dependencies.Editor
 
             ApplyStylesheet();
             SetUpFieldReferences();
+            SetUpConfigurationProperties();
             BindFields();
 
             Refresh();
@@ -50,9 +66,9 @@ namespace Chopsticks.Dependencies.Editor
         private void UpdateCurrentParentContainer()
         {
             var parentSetting = (ContainerSetting)(serializedObject
-                .FindProperty("_containerParentSetting").enumValueIndex - 1);
+                .FindProperty(ContainerParentSetting).enumValueIndex - 1);
             var overrideParent = (BaseUnityContainer)serializedObject
-                .FindProperty("_overrideParent").objectReferenceValue;
+                .FindProperty(OverrideParent).objectReferenceValue;
 
             IUnityContainerEditor parentContainer = null;
             if (parentSetting != ContainerSetting.None)
@@ -91,7 +107,7 @@ namespace Chopsticks.Dependencies.Editor
                 return;
 
             var parentSetting = (ContainerSetting)(serializedObject
-                .FindProperty("_containerParentSetting").enumValueIndex - 1);
+                .FindProperty(ContainerParentSetting).enumValueIndex - 1);
             
             _inheritDependenciesField.style.display = parentSetting != ContainerSetting.None ? 
                 DisplayStyle.Flex : DisplayStyle.None;
@@ -109,9 +125,33 @@ namespace Chopsticks.Dependencies.Editor
 
         private void BindFields()
         {
-            _parentSettingField.BindProperty(serializedObject.FindProperty("_containerParentSetting"));
-            _inheritDependenciesField.BindProperty(serializedObject.FindProperty("_inheritParentDependencies"));
-            _overrideParentField.BindProperty(serializedObject.FindProperty("_overrideParent"));
+            _parentSettingField.BindProperty(serializedObject
+                .FindProperty(ContainerParentSetting));
+            _inheritDependenciesField.BindProperty(serializedObject
+                .FindProperty(InheritParentDependencies));
+            _overrideParentField.BindProperty(serializedObject
+                .FindProperty(OverrideParent));
+        }
+
+        private void SetUpConfigurationProperties()
+        {
+            _configurationContainer = _root.Q<VisualElement>("configurationContainer");
+            SerializedProperty property = serializedObject.GetIterator();
+            property.NextVisible(true); // Jump into the script reference's properties.
+
+            bool hasDrawnProperty = false;
+            while (property.NextVisible(false))
+            {
+                if (ExcludedProperties.Contains(property.name))
+                    continue;
+
+                PropertyField field = new(property);
+                _configurationContainer.Add(field);
+                hasDrawnProperty = true;
+            }
+
+            if (!hasDrawnProperty)
+                _configurationContainer.style.display = DisplayStyle.None;
         }
 
         private void SetUpFieldReferences()
@@ -128,7 +168,7 @@ namespace Chopsticks.Dependencies.Editor
 
 
         private T LoadAsset<T>(string assetFile)
-            where T : UnityEngine.Object
+            where T : Object
         {
             var visualTree = AssetDatabase.LoadAssetAtPath<T>(
                 $"Packages/com.chopsticks.dependencies/Editor/Containers/{assetFile}");

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.uss
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.uss
@@ -38,6 +38,14 @@ PropertyField {
     border-color: var(--unity-colors-default-border);
 }
 
+.configuration-container {
+    margin: 4px;
+    padding: 6px;
+    border-width: 1px;
+    border-radius: 3px;
+    border-color: var(--unity-colors-default-border);
+}
+
 .parent-state-label {
     margin-top: 3px;
     margin-bottom: 3px;

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.uxml
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.uxml
@@ -13,4 +13,7 @@
         <ui:Label text="None" name="parentStateLabel" class="parent-state-label" />
         <uie:ObjectField name="currentParent"/>
     </ui:VisualElement>
+    <ui:VisualElement name="configurationContainer" class="configuration-container">
+        <ui:Label class="section-header" text="Configuration"/>
+    </ui:VisualElement>
 </UXML> 


### PR DESCRIPTION
### What Changed?
- Added a configuration container that render the subclass properties of a BaseMonoContainer in the inspector.
### Why It Changed
- To enable configuration of custom subclasses of MonoContainer, which supports greater extendibility of containers.
### How to Test
**Subclass Property Rendering**
1. Add inspector-visible fields to MonoContainer.cs (or to any other subclass of BaseMonoContainer or MonoContainer).
2. Create a new GameObject in the hierarchy of any sample scene.
3. Attach MonoContainer (or the created subclass) to the new GameObject.
4. Verify that the inspector shows a `Configuration` container with the subclass's properties rendered in their default mode.
5. Remove the fields from MonoContainer (or the created subclass).
6. Verify that the inspector no longer shows a `Configuration` container, since there are no properties to render.