### PR TITLE
Add Monodependent Editor

### DIFF
--- a/Native/Dependencies/Containers/IDependencyContainerExtensions.cs
+++ b/Native/Dependencies/Containers/IDependencyContainerExtensions.cs
@@ -69,7 +69,7 @@ namespace Chopsticks.Dependencies.Containers
         /// <param name="container">The container registering the dependency.</param>
         /// <param name="implementationFactory">The factory for producing 
         /// resolving implementations.</param>
-        /// <param name="lifetime">The lifetime of that the registered 
+        /// <param name="lifetime">The lifetime that the registered 
         /// dependency will have.</param>
         /// <returns>This container, to chain additional manipulations.</returns>
         public static IDependencyContainer Register<TContract>(
@@ -92,7 +92,7 @@ namespace Chopsticks.Dependencies.Containers
         /// <param name="registration">The registration that can identify the dependency for 
         /// deregistration by <see cref="IDependencyContainer.Deregister(DependencyRegistration)"/>
         /// </param>
-        /// <param name="lifetime">The lifetime of that the registered 
+        /// <param name="lifetime">The lifetime that the registered 
         /// dependency will have.</param>
         /// <returns>This container, to chain additional manipulations.</returns>
         public static IDependencyContainer Register<TContract>(

--- a/Unity/com.chopsticks.dependencies/Assets/Samples/Scripts/ExampleDependencies/ExampleSystem/Counting/CountingSystem.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Samples/Scripts/ExampleDependencies/ExampleSystem/Counting/CountingSystem.cs
@@ -21,8 +21,8 @@ namespace Chopsticks.Samples.ExampleDependencies.ExampleSystem.Counting
         DependencyContainer IUnityContained<DependencyContainer>.Container { get; set; }
 
         /// <inheritdoc/>
-        ContainerSetting IUnityContained<DependencyContainer>.ContainerSetting => 
-            ContainerSetting.HierarchyWithGlobal;
+        ContainerRetrievalSetting IUnityContained<DependencyContainer>.ContainerSetting =>
+            ContainerRetrievalSetting.Hierarchy;
 
 
         /// <inheritdoc/>

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependencyEditor.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependencyEditor.cs
@@ -1,0 +1,11 @@
+﻿using UnityEditor;
+
+namespace Chopsticks.Dependencies.Editor
+{
+    [CustomEditor(typeof(BaseMonoDependency<,>), true)]
+    public class BaseMonoDependencyEditor : BaseMonoDependentEditor
+    {
+        /// <inheritdoc/>
+        protected override string Title => "Chopsticks Dependency";
+    }
+} 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependencyEditor.cs.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependencyEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd2cd5fa63d8d1b409f2886d27e540cd

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependencyWrapperEditor.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependencyWrapperEditor.cs
@@ -1,0 +1,12 @@
+﻿using UnityEditor;
+
+namespace Chopsticks.Dependencies.Editor
+{
+    [CustomEditor(typeof(BaseMonoDependencyWrapper<,>), true)]
+    public class BaseMonoDependencyWrapperEditor : BaseMonoDependentEditor
+    {
+        // Maintain through the editor title that a wrapper is the same as a real dependency.
+        /// <inheritdoc/>
+        protected override string Title => "Chopsticks Dependency";
+    }
+} 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependencyWrapperEditor.cs.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependencyWrapperEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88a96ef5d3a3326419bf9f0bf8685ef1

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.cs
@@ -1,0 +1,180 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEditor;
+using UnityEditor.UIElements;
+using Chopsticks.Dependencies.Containers;
+using System.Collections.Generic;
+
+namespace Chopsticks.Dependencies.Editor
+{
+    [CustomEditor(typeof(BaseMonoDependent<,>), true)]
+    public class BaseMonoDependentEditor : UnityEditor.Editor
+    {
+        private const string ContainerSetting = "_containerSetting";
+        private const string OverrideContainer = "_overrideContainer";
+
+        private static readonly HashSet<string> ExcludedProperties = new()
+        {
+            ContainerSetting,
+            OverrideContainer
+        };
+
+
+        protected virtual string Title => "Chopsticks Dependent";
+
+        private VisualElement _root;
+
+        private VisualElement _configurationContainer;
+        private PropertyField _containerSettingField;
+        private ObjectField _currentParentField;
+        private PropertyField _overrideContainerField;
+        private Label _parentStateLabel;
+        private Label _titleLabel;
+
+
+        public override VisualElement CreateInspectorGUI()
+        {
+            var visualTree = LoadAsset<VisualTreeAsset>("BaseMonoDependentEditor.uxml");
+            _root = visualTree.Instantiate();
+
+            ApplyStylesheet();
+            SetUpFieldReferences();
+            SetUpConfigurationProperties();
+            BindFields();
+
+            Refresh();
+            EditorApplication.update += Refresh;
+
+            return _root;
+        }
+
+        public void OnDestroy() => 
+            EditorApplication.update -= Refresh;
+
+
+        private void Refresh()
+        {
+            // Prevent containers from being disabled, since that isn't supported.
+            if (target != null && !((MonoBehaviour)target).enabled)
+                ((MonoBehaviour)target).enabled = true;
+
+            UpdateForParentSetting();
+            UpdateCurrentParentContainer();
+        }
+        
+
+        private void UpdateCurrentParentContainer()
+        {
+            var containerSetting = (ContainerRetrievalSetting)serializedObject
+                .FindProperty(ContainerSetting).enumValueIndex;
+            var overrideParent = (BaseUnityContainer)serializedObject
+                .FindProperty(OverrideContainer).objectReferenceValue;
+
+            MonoBehaviour parentContainer = 
+                UnityEditorContainerService.FindParentUnityContainer
+                <BaseUnityContainer, BaseUnityContainer>(
+                    (ContainerSetting)containerSetting, (MonoBehaviour)target, 
+                    overrideParent);
+
+            _currentParentField.value = parentContainer;
+            var hasParent = parentContainer != null;
+
+            bool showObjectField = containerSetting == ContainerRetrievalSetting.Override ||
+                containerSetting == ContainerRetrievalSetting.Hierarchy && hasParent;
+
+            _currentParentField.style.display = showObjectField ? 
+                DisplayStyle.Flex : DisplayStyle.None;
+            _parentStateLabel.style.display = !showObjectField ? 
+                DisplayStyle.Flex : DisplayStyle.None;
+
+            if (!showObjectField)
+            {
+                string stateText = containerSetting switch
+                {
+                    ContainerRetrievalSetting.Global => "Global",
+                    ContainerRetrievalSetting.Hierarchy when !hasParent => "Global",
+                    _ => "None (No Parent Found)"
+                };
+                _parentStateLabel.text = stateText;
+            }
+        }
+
+        private void UpdateForParentSetting()
+        {
+            if (serializedObject == null)
+                return;
+
+            var containerSetting = (ContainerRetrievalSetting)serializedObject
+                .FindProperty(ContainerSetting).enumValueIndex;
+
+            _overrideContainerField.style.display = 
+                containerSetting == ContainerRetrievalSetting.Override ?
+                DisplayStyle.Flex : DisplayStyle.None;
+        }
+
+
+        private void ApplyStylesheet()
+        {
+            var styleSheet = LoadAsset<StyleSheet>("BaseMonoDependentEditor.uss");
+            if (styleSheet != null)
+                _root.styleSheets.Add(styleSheet);
+        }
+
+        private void BindFields()
+        {
+            _containerSettingField.BindProperty(serializedObject
+                .FindProperty(ContainerSetting));
+            _overrideContainerField.BindProperty(serializedObject
+                .FindProperty(OverrideContainer));
+        }
+
+        private void SetUpConfigurationProperties()
+        {
+            _configurationContainer = _root.Q<VisualElement>("configurationContainer");
+            SerializedProperty property = serializedObject.GetIterator();
+            property.NextVisible(true); // Jump into the script reference's properties.
+
+            bool hasDrawnProperty = false;
+            while (property.NextVisible(false))
+            {
+                if (ExcludedProperties.Contains(property.name))
+                    continue;
+
+                PropertyField field = new(property);
+                _configurationContainer.Add(field);
+                hasDrawnProperty = true;
+            }
+
+            if (!hasDrawnProperty)
+                _configurationContainer.style.display = DisplayStyle.None;
+        }
+
+        private void SetUpFieldReferences()
+        {
+            _containerSettingField = _root.Q<PropertyField>("containerSetting");
+            _overrideContainerField = _root.Q<PropertyField>("overrideContainer");
+
+            _titleLabel = _root.Q<Label>("titleLabel");
+            _titleLabel.text = Title;
+            _parentStateLabel = _root.Q<Label>("containerStateLabel");
+
+            _currentParentField = _root.Q<ObjectField>("currentContainer");
+            _currentParentField.objectType = typeof(BaseUnityContainer);
+            _currentParentField.SetEnabled(false);
+        }
+
+
+        private T LoadAsset<T>(string assetFile)
+            where T : Object
+        {
+            var visualTree = AssetDatabase.LoadAssetAtPath<T>(
+                $"Packages/com.chopsticks.dependencies/Editor/{assetFile}");
+
+            if (visualTree == null)  // Running in development package environment.
+                visualTree = AssetDatabase.LoadAssetAtPath<T>(
+                    $"Assets/Scripts/Editor/{assetFile}");
+
+            return visualTree;
+        }
+    }
+} 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.cs
@@ -20,6 +20,9 @@ namespace Chopsticks.Dependencies.Editor
         };
 
 
+        /// <summary>
+        /// The title in the inspector.
+        /// </summary>
         protected virtual string Title => "Chopsticks Dependent";
 
         private VisualElement _root;

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.cs.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3fadcecb6fa326e40b808c667235913e

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.uss
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.uss
@@ -1,0 +1,53 @@
+.title {
+    -unity-font-style: bold;
+    -unity-text-align: middle-center;
+    font-size: 18px;
+    padding: 5px;
+    margin-bottom: 4px;
+}
+
+.subtitle {
+    -unity-font-style: bold;
+    margin-top: 10px;
+    margin-bottom: 5px;
+}
+
+.section-header {
+    -unity-font-style: bold;
+    font-size: 14px;
+    margin-bottom: 2px;
+}
+
+PropertyField {
+    margin: 2px 0;
+}
+
+.settings-container {
+    margin: 4px;
+    padding: 6px;
+    border-width: 1px;
+    border-radius: 3px;
+    border-color: var(--unity-colors-default-border);
+}
+
+.info-container {
+    margin: 4px;
+    padding: 6px;
+    border-width: 1px;
+    border-radius: 3px;
+    border-color: var(--unity-colors-default-border);
+}
+
+.configuration-container {
+    margin: 4px;
+    padding: 6px;
+    border-width: 1px;
+    border-radius: 3px;
+    border-color: var(--unity-colors-default-border);
+}
+
+.container-state-label {
+    margin-top: 3px;
+    margin-bottom: 3px;
+    margin-left: 4px;
+}

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.uss.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02ccd3e094fdb814298922024150f585
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.uxml
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.uxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+    <ui:Label name="titleLabel" class="title" text="Chopsticks Dependent"/>
+    <ui:VisualElement class="settings-container">
+        <ui:Label class="section-header" text="Settings"/>
+        <uie:PropertyField name="containerSetting" label="Container Setting"/>
+        <uie:PropertyField name="overrideContainer" label="Override Container"/>
+    </ui:VisualElement>
+    <ui:VisualElement class="info-container">
+        <ui:Label class="section-header" text="Info"/>
+        <ui:Label class="subtitle" text="Current Container"/>
+        <ui:Label text="None" name="containerStateLabel" class="container-state-label" />
+        <uie:ObjectField name="currentContainer"/>
+    </ui:VisualElement>
+    <ui:VisualElement name="configurationContainer" class="configuration-container">
+        <ui:Label class="section-header" text="Configuration"/>
+    </ui:VisualElement>
+</UXML> 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.uxml.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/BaseMonoDependentEditor.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 7d811e427c3c37f4891e9f4152f3b333
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/BaseMonoContainerEditor.cs
@@ -65,17 +65,18 @@ namespace Chopsticks.Dependencies.Editor
         private void UpdateCurrentParentContainer()
         {
             var parentSetting = (ContainerSetting)(serializedObject
-                .FindProperty(ContainerParentSetting).enumValueIndex - 1);
+                .FindProperty(ContainerParentSetting).enumValueIndex - 2);  // Offset, as None is -2.
             var overrideParent = (BaseUnityContainer)serializedObject
                 .FindProperty(OverrideParent).objectReferenceValue;
 
-            IUnityContainerEditor parentContainer = null;
+            MonoBehaviour parentContainer = null;
             if (parentSetting != ContainerSetting.None)
-                parentContainer = UnityEditorContainerService.FindParentUnityContainer(
-                    (ContainerRetrievalSetting)parentSetting, (BaseUnityContainer)target, 
+                parentContainer = UnityEditorContainerService.FindParentUnityContainer
+                    <BaseUnityContainer, BaseUnityContainer>(
+                    parentSetting, (MonoBehaviour)target, 
                     overrideParent);
 
-            _currentParentField.value = parentContainer as MonoBehaviour;
+            _currentParentField.value = parentContainer;
             var hasParent = parentContainer != null;
 
             bool showObjectField = parentSetting == ContainerSetting.Override ||
@@ -106,8 +107,8 @@ namespace Chopsticks.Dependencies.Editor
                 return;
 
             var parentSetting = (ContainerSetting)(serializedObject
-                .FindProperty(ContainerParentSetting).enumValueIndex - 1);
-            
+                .FindProperty(ContainerParentSetting).enumValueIndex - 2);  // Offset, as None is -2.
+
             _inheritDependenciesField.style.display = parentSetting != ContainerSetting.None ? 
                 DisplayStyle.Flex : DisplayStyle.None;
             _overrideParentField.style.display = parentSetting == ContainerSetting.Override ? 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/UnityEditorContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Editor/Containers/UnityEditorContainerService.cs
@@ -9,36 +9,35 @@ namespace Chopsticks.Dependencies.Containers
     public static class UnityEditorContainerService
     {
         /// <summary>
-        /// Finds the parent Unity container of the given Unity container, 
+        /// Finds the parent Unity container of the given MonoBehaviour, 
         /// per the specified <see cref="ContainerRetrievalSetting"/>.
         /// </summary>
-        /// <typeparam name="TUnityContainer">The type of the Unity container whose 
-        /// same typed parent will be searched for.</typeparam>
+        /// <typeparam name="TUnityContainer">The type of containing parent 
+        /// will be searched for.</typeparam>
         /// <param name="setting">The setting that defines the strategy applied 
         /// to find the parent container.</param>
-        /// <param name="unityContainer">The Unity container whose parent will be 
+        /// <param name="unityContainer">The MonoBehaviour whose parent will be 
         /// searched for.</param>
         /// <param name="overrideContainer">The wrapping Unity container of a container 
         /// that may be provided per some settings.</param>
-        /// <returns>The found parent container, or null if either no such 
-        /// container could be found or if the specified override is actually a child of the 
-        /// provided Unity container.</returns>
-        public static IUnityContainerEditor FindParentUnityContainer<
+        /// <returns>The found parent container, as a MonoBehaviour.</returns>
+        public static MonoBehaviour FindParentUnityContainer<
             TUnityContainer, TOverrideContainer>(
-            ContainerRetrievalSetting setting, TUnityContainer unityContainer, 
+            ContainerSetting setting, MonoBehaviour unityContainer, 
             TOverrideContainer overrideContainer)
-            where TUnityContainer : MonoBehaviour, IUnityContainerEditor
-            where TOverrideContainer : MonoBehaviour, IUnityContainerEditor =>
+            where TUnityContainer : MonoBehaviour
+            where TOverrideContainer : MonoBehaviour =>
             setting switch
             {
-                ContainerRetrievalSetting.HierarchyWithGlobal =>
+                ContainerSetting.HierarchyWithGlobal =>
                     unityContainer.transform.parent == null ? null : 
                         unityContainer.transform.parent.GetComponentInParent<TUnityContainer>(),
-                ContainerRetrievalSetting.HierarchyWithoutGlobal =>
+                ContainerSetting.HierarchyWithoutGlobal =>
                     unityContainer.transform.parent == null ? null : 
                         unityContainer.transform.parent.GetComponentInParent<TUnityContainer>(),
-                ContainerRetrievalSetting.Global => null,
-                ContainerRetrievalSetting.Override => overrideContainer,
+                ContainerSetting.Global => null,
+                ContainerSetting.Override => overrideContainer,
+                ContainerSetting.None => null,
                 _ => throw new NotSupportedException($"The container retrieval setting of " +
                                         $"{setting} is not supported."),
             };

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/BaseMonoDependent.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/BaseMonoDependent.cs
@@ -18,9 +18,9 @@ namespace Chopsticks.Dependencies
         TNativeContainer IUnityContained<TNativeContainer>.Container { get; set; }
 
         ///<inheritdoc/>
-        ContainerSetting IUnityContained<TNativeContainer>.ContainerSetting => _containerSetting;
+        ContainerRetrievalSetting IUnityContained<TNativeContainer>.ContainerSetting => _containerSetting;
         [SerializeField]
-        private ContainerSetting _containerSetting = ContainerSetting.HierarchyWithGlobal;
+        private ContainerRetrievalSetting _containerSetting = ContainerRetrievalSetting.Hierarchy;
 
         /// <summary>
         /// The container that may serve as an overriding container for this dependent.
@@ -40,6 +40,10 @@ namespace Chopsticks.Dependencies
         ///<inheritdoc/>
         public virtual void OnTransformParentChanged() => 
             this.UpdateContainer(this, _overrideContainer, null, ResolveDependencies);
+
+        ///<inheritdoc/>
+        protected virtual void OnValidate() =>
+            this.UpdateContainer(this, _overrideContainer, null, null);
 
 
         /// <summary>

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IUnityContained.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IUnityContained.cs
@@ -21,6 +21,6 @@ namespace Chopsticks.Dependencies.Contained
         /// <summary>
         /// The setting that specifies how the <see cref="Container"/> is found.
         /// </summary>
-        ContainerSetting ContainerSetting { get; }
+        ContainerRetrievalSetting ContainerSetting { get; }
     }
 }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IUnityDependentExtensions.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Contained/IUnityDependentExtensions.cs
@@ -34,7 +34,7 @@ namespace Chopsticks.Dependencies.Contained
             where TUnityContainerService : IUnityContainerService<TNativeContainer>, new()
             where TOverrideContainer : IUnityContainer<TNativeContainer> =>
                 dependent.Service.GetContainer(
-                    (ContainerRetrievalSetting)dependent.ContainerSetting,
+                    (ContainerSetting)dependent.ContainerSetting,
                     true, unityContained, overrideContainer);
 
         /// <summary>
@@ -65,11 +65,9 @@ namespace Chopsticks.Dependencies.Contained
             if (!unityContained.enabled)
                 return;
 
-            TNativeContainer updatedContainer = default;
-            if (dependent.ContainerSetting != ContainerSetting.None)
-                updatedContainer = dependent.Service.GetContainer(
-                    (ContainerRetrievalSetting)dependent.ContainerSetting,
-                    true, unityContained.transform, overrideContainer);
+            TNativeContainer updatedContainer = dependent.Service.GetContainer(
+                (ContainerSetting)dependent.ContainerSetting, 
+                true, unityContained.transform, overrideContainer);
 
             if (dependent.Container == null)
             {

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/BaseMonoContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/BaseMonoContainer.cs
@@ -142,7 +142,7 @@ namespace Chopsticks.Dependencies.Containers
             }
 
             InternalContainer.Parent = ContainerService.FindParentContainer(
-                (ContainerRetrievalSetting)_containerParentSetting, this, _overrideParent);
+                _containerParentSetting, this, _overrideParent);
 
             if (_containerParentSetting == ContainerSetting.Override &&
                 InternalContainer.Parent == null && _overrideParent != null)

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/BaseUnityContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/BaseUnityContainer.cs
@@ -1,5 +1,4 @@
-﻿using Chopsticks.Dependencies.Contained;
-using Chopsticks.Dependencies.Resolutions;
+﻿using Chopsticks.Dependencies.Resolutions;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -11,7 +10,7 @@ namespace Chopsticks.Dependencies.Containers
     /// are contained within this container. This enables the organization 
     /// of dependencies to be defined through the Unity hierarchy and prefabs.
     /// </summary>
-    public abstract class BaseUnityContainer : MonoBehaviour, IUnityContainerEditor
+    public abstract class BaseUnityContainer : MonoBehaviour
     {
     }
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/ContainerRetrievalSetting.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/ContainerRetrievalSetting.cs
@@ -10,19 +10,14 @@
         /// The retrieved container will be found through the hierarchy, 
         /// defaulting to the global container if no container can be found.
         /// </summary>
-        HierarchyWithGlobal = 0,
-        /// <summary>
-        /// The retrieved container will be found through the hierarchy and 
-        /// will return null if no container can be found.
-        /// </summary>
-        HierarchyWithoutGlobal = 1,
+        Hierarchy = 0,
         /// <summary>
         /// The retrieved container will be the global container.
         /// </summary>
-        Global = 2,
+        Global = 1,
         /// <summary>
         /// The retrieved container will be a specified override container.
         /// </summary>
-        Override = 3
+        Override = 2
     }
 }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/ContainerSetting.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Containers/ContainerSetting.cs
@@ -9,17 +9,17 @@
         /// <summary>
         /// The contained will have no container.
         /// </summary>
-        None = -1,
-        /// <summary>
-        /// The contained will find its parent through the hierarchy, 
-        /// defaulting to the global container if no parent can be found.
-        /// </summary>
-        HierarchyWithGlobal = ContainerRetrievalSetting.HierarchyWithGlobal,
+        None = -2,
         /// <summary>
         /// The contained will find its parent through the hierarchy and 
         /// will have no parent if one cannot be found.
         /// </summary>
-        HierarchyWithoutGlobal = ContainerRetrievalSetting.HierarchyWithoutGlobal,
+        HierarchyWithoutGlobal = -1,
+        /// <summary>
+        /// The contained will find its parent through the hierarchy, 
+        /// defaulting to the global container if no parent can be found.
+        /// </summary>
+        HierarchyWithGlobal = ContainerRetrievalSetting.Hierarchy,
         /// <summary>
         /// The contained will be a child of the global container.
         /// </summary>

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/IUnityContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/IUnityContainerService.cs
@@ -15,7 +15,7 @@ namespace Chopsticks.Dependencies.Services
     {
         /// <summary>
         /// Finds the parent container of the given Unity container, 
-        /// per the specified <see cref="ContainerRetrievalSetting"/>.
+        /// per the specified <see cref="ContainerSetting"/>.
         /// </summary>
         /// <typeparam name="TUnityContainer">The type of the Unity container whose 
         /// parent will be searched for.</typeparam>
@@ -31,14 +31,14 @@ namespace Chopsticks.Dependencies.Services
         /// container could be found or if the specified override is actually a child of the 
         /// provided Unity container.</returns>
         TNativeContainer FindParentContainer<TUnityContainer, TOverrideContainer>(
-            ContainerRetrievalSetting setting, TUnityContainer unityContainer,
+            ContainerSetting setting, TUnityContainer unityContainer,
             TOverrideContainer overrideContainer)
             where TUnityContainer : MonoBehaviour, IUnityContainer<TNativeContainer>
             where TOverrideContainer : IUnityContainer<TNativeContainer>;
 
         /// <summary>
         /// Provides a dependency container per the specified 
-        /// <see cref="ContainerRetrievalSetting"/>, starting from the given contained 
+        /// <see cref="ContainerSetting"/>, starting from the given contained 
         /// Unity construct.
         /// </summary>
         /// <typeparam name="TOverrideContainer">The type of the container that may 
@@ -55,7 +55,7 @@ namespace Chopsticks.Dependencies.Services
         /// <returns>A container retrieved per the specified setting, 
         /// or null if no such container could be found.</returns>
         TNativeContainer GetContainer<TOverrideContainer>(
-            ContainerRetrievalSetting setting, bool includeSelf,
+            ContainerSetting setting, bool includeSelf,
             Transform unityContained, TOverrideContainer overrideContainer)
             where TOverrideContainer : IUnityContainer<TNativeContainer>;
 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/UnityContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Runtime/Services/UnityContainerService.cs
@@ -53,23 +53,24 @@ namespace Chopsticks.Dependencies.Services
 
         /// <inheritdoc/>
         /// <exception cref="NotSupportedException">Thrown if a  
-        /// <see cref="ContainerRetrievalSetting"/>is not supported.</exception>
+        /// <see cref="ContainerSetting"/>is not supported.</exception>
         public virtual TNativeContainer FindParentContainer<TUnityContainer, TOverrideContainer>(
-            ContainerRetrievalSetting setting, TUnityContainer unityContainer,
+            ContainerSetting setting, TUnityContainer unityContainer,
             TOverrideContainer overrideContainer)
             where TUnityContainer : MonoBehaviour, IUnityContainer<TNativeContainer>
             where TOverrideContainer : IUnityContainer<TNativeContainer> =>
             setting switch
             {
-                ContainerRetrievalSetting.HierarchyWithGlobal =>
+                ContainerSetting.HierarchyWithGlobal =>
                     GetContainer(setting, false, unityContainer.transform, overrideContainer),
-                ContainerRetrievalSetting.HierarchyWithoutGlobal =>
+                ContainerSetting.HierarchyWithoutGlobal =>
                     GetContainer(setting, false, unityContainer.transform, overrideContainer),
-                ContainerRetrievalSetting.Global => 
+                ContainerSetting.Global => 
                     _globalContainer,
-                ContainerRetrievalSetting.Override =>
+                ContainerSetting.Override =>
                     ValidateOverrideParent(unityContainer, overrideContainer) == null ? default : 
                         overrideContainer.NativeContainer,
+                ContainerSetting.None => default,
                 _ => throw new NotSupportedException($"The container retrieval setting of " +
                                         $"{setting} is not supported."),
             };
@@ -78,21 +79,22 @@ namespace Chopsticks.Dependencies.Services
         /// <exception cref="NotSupportedException">Thrown if a  
         /// <see cref="ContainerRetrievalSetting"/>is not supported.</exception>
         public virtual TNativeContainer GetContainer<TOverrideContainer>(
-            ContainerRetrievalSetting setting, bool includeSelf, 
+            ContainerSetting setting, bool includeSelf, 
             Transform unityContained, TOverrideContainer overrideContainer)
             where TOverrideContainer : IUnityContainer<TNativeContainer> =>
             setting switch
             {
-                ContainerRetrievalSetting.HierarchyWithGlobal =>
+                ContainerSetting.HierarchyWithGlobal =>
                     FindContainerInHierarchy(includeSelf ? 
                         unityContained : unityContained.parent, true),
-                ContainerRetrievalSetting.HierarchyWithoutGlobal =>
+                ContainerSetting.HierarchyWithoutGlobal =>
                     FindContainerInHierarchy(includeSelf ? 
                         unityContained : unityContained.parent, false),
-                ContainerRetrievalSetting.Global =>
+                ContainerSetting.Global =>
                     _globalContainer,
-                ContainerRetrievalSetting.Override => 
+                ContainerSetting.Override => 
                     overrideContainer == null ? default : overrideContainer.NativeContainer,
+                ContainerSetting.None => default,
                 _ => throw new NotSupportedException($"The container retrieval setting of " +
                                         $"{setting} is not supported."),
             };

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyExtensionsTests/Mocks/MockRegistrationContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyExtensionsTests/Mocks/MockRegistrationContainerService.cs
@@ -12,13 +12,13 @@ namespace IUnityDependencyExtensionsTests.Mocks
             Substitute.For<IUnityContainerService<MockRegistrationDependencyContainer>>();
 
         public MockRegistrationDependencyContainer FindParentContainer<TUnityContainer, TOverrideContainer>(
-            ContainerRetrievalSetting setting, TUnityContainer unityContainer, TOverrideContainer overrideContainer)
+            ContainerSetting setting, TUnityContainer unityContainer, TOverrideContainer overrideContainer)
             where TUnityContainer : MonoBehaviour, IUnityContainer<MockRegistrationDependencyContainer>
             where TOverrideContainer : IUnityContainer<MockRegistrationDependencyContainer> =>
                 Sub.FindParentContainer(setting, unityContainer, overrideContainer);
 
         public MockRegistrationDependencyContainer GetContainer<TOverrideContainer>(
-            ContainerRetrievalSetting setting, bool includeSelf, Transform unityContained, 
+            ContainerSetting setting, bool includeSelf, Transform unityContained, 
             TOverrideContainer overrideContainer)
             where TOverrideContainer : IUnityContainer<MockRegistrationDependencyContainer> => 
                 Sub.GetContainer(setting, includeSelf, unityContained, overrideContainer);

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyWrapperExtensionsTests/Mocks/MockRegistrationContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependencyWrapperExtensionsTests/Mocks/MockRegistrationContainerService.cs
@@ -12,13 +12,13 @@ namespace IUnityDependencyWrapperExtensionsTests.Mocks
             Substitute.For<IUnityContainerService<MockRegistrationDependencyContainer>>();
 
         public MockRegistrationDependencyContainer FindParentContainer<TUnityContainer, TOverrideContainer>(
-            ContainerRetrievalSetting setting, TUnityContainer unityContainer, TOverrideContainer overrideContainer)
+            ContainerSetting setting, TUnityContainer unityContainer, TOverrideContainer overrideContainer)
             where TUnityContainer : MonoBehaviour, IUnityContainer<MockRegistrationDependencyContainer>
             where TOverrideContainer : IUnityContainer<MockRegistrationDependencyContainer> =>
                 Sub.FindParentContainer(setting, unityContainer, overrideContainer);
 
         public MockRegistrationDependencyContainer GetContainer<TOverrideContainer>(
-            ContainerRetrievalSetting setting, bool includeSelf, Transform unityContained, 
+            ContainerSetting setting, bool includeSelf, Transform unityContained, 
             TOverrideContainer overrideContainer)
             where TOverrideContainer : IUnityContainer<MockRegistrationDependencyContainer> => 
                 Sub.GetContainer(setting, includeSelf, unityContained, overrideContainer);

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/FindContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/FindContainer.cs
@@ -34,10 +34,10 @@ namespace IUnityDependentExtensionsTests
             var transform = new GameObject().transform;
             var overrideContainer = Substitute.For<IUnityContainer<MockDependencyContainer>>();
             
-            var setting = ContainerSetting.Override;
+            var setting = ContainerRetrievalSetting.Override;
             unityDependent.ContainerSetting.Returns(setting);
             
-            mockService.GetContainer((ContainerRetrievalSetting)setting, true, transform, 
+            mockService.GetContainer((ContainerSetting)setting, true, transform, 
                 overrideContainer).Returns(expectedContainer);
 
             // Act
@@ -45,7 +45,7 @@ namespace IUnityDependentExtensionsTests
 
             // Assert
             Assert.That(container, Is.EqualTo(expectedContainer));
-            mockService.Received(1).GetContainer((ContainerRetrievalSetting)setting, true, 
+            mockService.Received(1).GetContainer((ContainerSetting)setting, true, 
                 transform, overrideContainer);
         }
     }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/Mocks/MockUnityDependent.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/Mocks/MockUnityDependent.cs
@@ -8,7 +8,7 @@ namespace IUnityDependentExtensionsTests.Mocks
         IUnityDependent<MockDependencyContainer, MockMonoContainerService>
     {
         public abstract MockDependencyContainer Container { get; set; }
-        public abstract ContainerSetting ContainerSetting { get; }
+        public abstract ContainerRetrievalSetting ContainerSetting { get; }
 
         public abstract void OnEnable();
         public abstract void OnTransformParentChanged();

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/UpdateContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/IUnityDependentExtensionsTests/UpdateContainer.cs
@@ -19,7 +19,7 @@ namespace IUnityDependentExtensionsTests
         public static class SetUp
         {
             public static IUnityDependent<MockDependencyContainer, MockMonoContainerService> StandardDependent(
-                ContainerSetting containerSetting, MockDependencyContainer initialContainer,
+                ContainerRetrievalSetting containerSetting, MockDependencyContainer initialContainer,
                 bool enabledGameObject, out MockMonoDependent monoBehaviour, 
                 out IUnityContainer<MockDependencyContainer> overrideContainer,
                 out MonoContainerService serviceSub)
@@ -43,7 +43,7 @@ namespace IUnityDependentExtensionsTests
             }
 
             public static IUnityDependent<MockDependencyContainer, MockMonoContainerService> ChangeableContainer(
-                ContainerSetting containerSetting, bool initContainerIsNull,
+                ContainerRetrievalSetting containerSetting, bool initContainerIsNull,
                 out MockMonoDependent monoBehaviour,
                 out IUnityContainer<MockDependencyContainer> overrideContainer,
                 out MonoContainerService serviceSub)
@@ -54,7 +54,7 @@ namespace IUnityDependentExtensionsTests
                     true, out monoBehaviour, out overrideContainer, out serviceSub);
 
                 serviceSub.GetContainer(
-                    (ContainerRetrievalSetting)containerSetting,
+                    (ContainerSetting)containerSetting,
                     true,
                     monoBehaviour.transform,
                     overrideContainer).Returns(expectedContainer);
@@ -71,25 +71,18 @@ namespace IUnityDependentExtensionsTests
 
 
         [Test]
-        [TestCase(ContainerSetting.None, true)]
-        [TestCase(ContainerSetting.None, false)]
-        [TestCase(ContainerSetting.Global, true)]
-        [TestCase(ContainerSetting.Global, false)]
-        [TestCase(ContainerSetting.HierarchyWithGlobal, true)]
-        [TestCase(ContainerSetting.HierarchyWithGlobal, false)]
-        [TestCase(ContainerSetting.HierarchyWithoutGlobal, true)]
-        [TestCase(ContainerSetting.HierarchyWithoutGlobal, false)]
-        [TestCase(ContainerSetting.Override, true)]
-        [TestCase(ContainerSetting.Override, false)]
+        [TestCase(ContainerRetrievalSetting.Global, true)]
+        [TestCase(ContainerRetrievalSetting.Global, false)]
+        [TestCase(ContainerRetrievalSetting.Hierarchy, true)]
+        [TestCase(ContainerRetrievalSetting.Hierarchy, false)]
+        [TestCase(ContainerRetrievalSetting.Override, true)]
+        [TestCase(ContainerRetrievalSetting.Override, false)]
         public void SetContainer_AllContainerSettings_InvokesPostContainerChangedWhenContainerChanges(
-            ContainerSetting containerSetting, bool containerChanged)
+            ContainerRetrievalSetting containerSetting, bool containerChanged)
         {
             // Set up
-            var initContainerIsNull = containerSetting != ContainerSetting.None ?
-                containerChanged : !containerChanged;
-
             var unityDependent = SetUp.ChangeableContainer(containerSetting,
-                initContainerIsNull, out var monoBehaviour,
+                containerChanged, out var monoBehaviour,
                 out var overrideContainer, out var serviceSub);
 
             bool calledOnPostContainerChanged = false;
@@ -104,25 +97,18 @@ namespace IUnityDependentExtensionsTests
         }
 
         [Test]
-        [TestCase(ContainerSetting.None, true)]
-        [TestCase(ContainerSetting.None, false)]
-        [TestCase(ContainerSetting.Global, true)]
-        [TestCase(ContainerSetting.Global, false)]
-        [TestCase(ContainerSetting.HierarchyWithGlobal, true)]
-        [TestCase(ContainerSetting.HierarchyWithGlobal, false)]
-        [TestCase(ContainerSetting.HierarchyWithoutGlobal, true)]
-        [TestCase(ContainerSetting.HierarchyWithoutGlobal, false)]
-        [TestCase(ContainerSetting.Override, true)]
-        [TestCase(ContainerSetting.Override, false)]
+        [TestCase(ContainerRetrievalSetting.Global, true)]
+        [TestCase(ContainerRetrievalSetting.Global, false)]
+        [TestCase(ContainerRetrievalSetting.Hierarchy, true)]
+        [TestCase(ContainerRetrievalSetting.Hierarchy, false)]
+        [TestCase(ContainerRetrievalSetting.Override, true)]
+        [TestCase(ContainerRetrievalSetting.Override, false)]
         public void SetContainer_AllContainerSettings_InvokesPreContainerChangedWhenContainerChanges(
-            ContainerSetting containerSetting, bool containerChanged)
+            ContainerRetrievalSetting containerSetting, bool containerChanged)
         {
             // Set up
-            var initContainerIsNull = containerSetting != ContainerSetting.None ?
-                containerChanged : !containerChanged;
-
             var unityDependent = SetUp.ChangeableContainer(containerSetting,
-                initContainerIsNull, out var monoBehaviour,
+                containerChanged, out var monoBehaviour,
                 out var overrideContainer, out var serviceSub);
 
             bool calledOnPreContainerChanged = false;
@@ -137,55 +123,14 @@ namespace IUnityDependentExtensionsTests
         }
 
         [Test]
-        public void UpdateContainer_DisabledContained_DoesNothing()
-        {
-            // Set up
-            var unityDependent = SetUp.StandardDependent(ContainerSetting.None, null, false,
-                out var monoBehaviour, out _, out var serviceSub);
-
-            // Act
-            unityDependent.UpdateContainer(monoBehaviour, null, null, null);
-
-            // Assert
-            Assert.That(unityDependent.Container, Is.Null);
-            serviceSub.DidNotReceiveWithAnyArgs().GetContainer(
-                Arg.Any<ContainerRetrievalSetting>(),
-                Arg.Any<bool>(),
-                Arg.Any<Transform>(),
-                Arg.Any<IUnityContainer<MockDependencyContainer>>());
-        }
-
-        [Test]
-        public void UpdateContainer_NoneContainerSetting_ContainerSetToNull()
-        {
-            // Set up
-            var unityDependent = SetUp.StandardDependent(ContainerSetting.None,
-                Substitute.For<MockDependencyContainer>(), true,
-                out var monoBehaviour, out var overrideContainer, out var serviceSub);
-
-            // Act
-            unityDependent.UpdateContainer(monoBehaviour, overrideContainer, null, null);
-
-            // Assert
-            Assert.That(unityDependent.Container, Is.Null);
-            serviceSub.DidNotReceiveWithAnyArgs().GetContainer(
-                Arg.Any<ContainerRetrievalSetting>(),
-                Arg.Any<bool>(),
-                Arg.Any<Transform>(),
-                Arg.Any<IUnityContainer<MockDependencyContainer>>());
-        }
-
-        [Test]
-        [TestCase(ContainerSetting.Global, true)]
-        [TestCase(ContainerSetting.Global, false)]
-        [TestCase(ContainerSetting.HierarchyWithGlobal, true)]
-        [TestCase(ContainerSetting.HierarchyWithGlobal, false)]
-        [TestCase(ContainerSetting.HierarchyWithoutGlobal, true)]
-        [TestCase(ContainerSetting.HierarchyWithoutGlobal, false)]
-        [TestCase(ContainerSetting.Override, true)]
-        [TestCase(ContainerSetting.Override, false)]
+        [TestCase(ContainerRetrievalSetting.Global, true)]
+        [TestCase(ContainerRetrievalSetting.Global, false)]
+        [TestCase(ContainerRetrievalSetting.Hierarchy, true)]
+        [TestCase(ContainerRetrievalSetting.Hierarchy, false)]
+        [TestCase(ContainerRetrievalSetting.Override, true)]
+        [TestCase(ContainerRetrievalSetting.Override, false)]
         public void UpdateContainer_VariousContainerSettings_SetsToServiceProvidedContainer(
-            ContainerSetting containerSetting, bool containerChanged)
+            ContainerRetrievalSetting containerSetting, bool containerChanged)
         {
             // Set up
             var expectedContainer = Substitute.For<MockDependencyContainer>();
@@ -193,7 +138,7 @@ namespace IUnityDependentExtensionsTests
                 null, true, out var monoBehaviour, out var overrideContainer, out var serviceSub);
 
             serviceSub.GetContainer(
-                (ContainerRetrievalSetting)containerSetting,
+                (ContainerSetting)containerSetting,
                 true,
                 monoBehaviour.transform,
                 overrideContainer).Returns(expectedContainer);
@@ -204,7 +149,7 @@ namespace IUnityDependentExtensionsTests
             // Assert
             Assert.That(unityDependent.Container, Is.EqualTo(expectedContainer));
             serviceSub.Received().GetContainer(
-                (ContainerRetrievalSetting)containerSetting,
+                (ContainerSetting)containerSetting,
                 true,
                 monoBehaviour.transform,
                 overrideContainer);

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/ContainerParentSetting.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/ContainerParentSetting.cs
@@ -103,9 +103,11 @@ namespace MonoContainerTests
                 .Returns((MockDependencyContainer)null);
 
             // Act
-            LogAssert.ignoreFailingMessages = true;
+            LogAssert.Expect(LogType.Error, 
+                $"BaseMonoContainer :: Override parent was reset to 'null' " +
+                $"on the GameObject called '{containerGameObject.name}' to prevent a parent loop " +
+                $"with the GameObject called '{parentContainer.name}'.");
             containerGameObject.SetActive(true);
-            LogAssert.ignoreFailingMessages = false;
 
             // Assert
             container.GetSerializedProperty("_overrideParent", out var overrideParent);
@@ -163,16 +165,18 @@ namespace MonoContainerTests
         {
             // Set up
             var container = SetUp.StandardContainer(ParentSetting.Override,
-                out _, out var parentContainer, out var serviceSub);
+                out var containerGameObject, out var parentContainer, out var serviceSub);
 
             serviceSub.FindParentContainer(
                 ParentSetting.Override, container, parentContainer)
                 .Returns((MockDependencyContainer)null);
 
             // Act
-            LogAssert.ignoreFailingMessages = true;
+            LogAssert.Expect(LogType.Error,
+                $"BaseMonoContainer :: Override parent was reset to 'null' " +
+                $"on the GameObject called '{containerGameObject.name}' to prevent a parent loop " +
+                $"with the GameObject called '{parentContainer.name}'.");
             container.OnTransformParentChanged();
-            LogAssert.ignoreFailingMessages = false;
 
             // Assert
             container.GetSerializedProperty("_overrideParent", out var overrideParent);
@@ -230,16 +234,18 @@ namespace MonoContainerTests
         {
             // Set up
             var container = SetUp.StandardContainer(ParentSetting.Override,
-                out _, out var parentContainer, out var serviceSub);
+                out var containerGameObject, out var parentContainer, out var serviceSub);
 
             serviceSub.FindParentContainer(
                 ParentSetting.Override, container, parentContainer)
                 .Returns((MockDependencyContainer)null);
 
             // Act
-            LogAssert.ignoreFailingMessages = true;
+            LogAssert.Expect(LogType.Error,
+                $"BaseMonoContainer :: Override parent was reset to 'null' " +
+                $"on the GameObject called '{containerGameObject.name}' to prevent a parent loop " +
+                $"with the GameObject called '{parentContainer.name}'.");
             container.OnValidate();
-            LogAssert.ignoreFailingMessages = false;
 
             // Assert
             container.GetSerializedProperty("_overrideParent", out var overrideParent);

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/ContainerParentSetting.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/ContainerParentSetting.cs
@@ -62,7 +62,7 @@ namespace MonoContainerTests
                 out var containerGameObject, out var parentContainer, out var serviceSub);
 
             serviceSub.FindParentContainer(
-                (ContainerRetrievalSetting)parentSetting, container, parentContainer)
+                parentSetting, container, parentContainer)
                 .Returns(parentContainer.InternalContainer);
 
             // Act
@@ -72,7 +72,7 @@ namespace MonoContainerTests
             Assert.That(container.InternalContainer.Parent,
                 Is.EqualTo(parentContainer.InternalContainer));
             serviceSub.Received(1).FindParentContainer(
-                (ContainerRetrievalSetting)parentSetting, container, parentContainer);
+                parentSetting, container, parentContainer);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace MonoContainerTests
             // Assert
             Assert.That(container.InternalContainer.Parent, Is.Null);
             serviceSub.DidNotReceiveWithAnyArgs().FindParentContainer(
-                ContainerRetrievalSetting.Global, container, parentContainer);
+                ParentSetting.Global, container, parentContainer);
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace MonoContainerTests
                 out var containerGameObject, out var parentContainer, out var serviceSub);
 
             serviceSub.FindParentContainer(
-                ContainerRetrievalSetting.Override, container, parentContainer)
+                ParentSetting.Override, container, parentContainer)
                 .Returns((MockDependencyContainer)null);
 
             // Act
@@ -112,7 +112,7 @@ namespace MonoContainerTests
 
             Assert.That(overrideParent, Is.Null);
             serviceSub.Received(1).FindParentContainer(
-                ContainerRetrievalSetting.Override, container, parentContainer);
+                ParentSetting.Override, container, parentContainer);
         }
 
 
@@ -129,7 +129,7 @@ namespace MonoContainerTests
                 out _, out var parentContainer, out var serviceSub);
 
             serviceSub.FindParentContainer(
-                (ContainerRetrievalSetting)parentSetting, container, parentContainer)
+                parentSetting, container, parentContainer)
                 .Returns(parentContainer.InternalContainer);
 
             // Act
@@ -139,7 +139,7 @@ namespace MonoContainerTests
             Assert.That(container.InternalContainer.Parent,
                 Is.EqualTo(parentContainer.InternalContainer));
             serviceSub.Received(1).FindParentContainer(
-                (ContainerRetrievalSetting)parentSetting, container, parentContainer);
+                parentSetting, container, parentContainer);
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace MonoContainerTests
             // Assert
             Assert.That(container.InternalContainer.Parent, Is.Null);
             serviceSub.DidNotReceiveWithAnyArgs().FindParentContainer(
-                ContainerRetrievalSetting.Global, container, parentContainer);
+                ParentSetting.Global, container, parentContainer);
         }
 
         [Test]
@@ -166,7 +166,7 @@ namespace MonoContainerTests
                 out _, out var parentContainer, out var serviceSub);
 
             serviceSub.FindParentContainer(
-                ContainerRetrievalSetting.Override, container, parentContainer)
+                ParentSetting.Override, container, parentContainer)
                 .Returns((MockDependencyContainer)null);
 
             // Act
@@ -179,7 +179,7 @@ namespace MonoContainerTests
 
             Assert.That(overrideParent, Is.Null);
             serviceSub.Received(1).FindParentContainer(
-                ContainerRetrievalSetting.Override, container, parentContainer);
+                ParentSetting.Override, container, parentContainer);
         }
 
 
@@ -196,7 +196,7 @@ namespace MonoContainerTests
                 out _, out var parentContainer, out var serviceSub);
 
             serviceSub.FindParentContainer(
-                (ContainerRetrievalSetting)parentSetting, container, parentContainer)
+                parentSetting, container, parentContainer)
                 .Returns(parentContainer.InternalContainer);
 
             // Act
@@ -206,7 +206,7 @@ namespace MonoContainerTests
             Assert.That(container.InternalContainer.Parent,
                 Is.EqualTo(parentContainer.InternalContainer));
             serviceSub.Received(1).FindParentContainer(
-                (ContainerRetrievalSetting)parentSetting, container, parentContainer);
+                parentSetting, container, parentContainer);
         }
 
         [Test]
@@ -222,7 +222,7 @@ namespace MonoContainerTests
             // Assert
             Assert.That(container.InternalContainer.Parent, Is.Null);
             serviceSub.DidNotReceiveWithAnyArgs().FindParentContainer(
-                ContainerRetrievalSetting.Global, container, parentContainer);
+                ParentSetting.Global, container, parentContainer);
         }
 
         [Test]
@@ -233,9 +233,8 @@ namespace MonoContainerTests
                 out _, out var parentContainer, out var serviceSub);
 
             serviceSub.FindParentContainer(
-                ContainerRetrievalSetting.Override, container, parentContainer)
+                ParentSetting.Override, container, parentContainer)
                 .Returns((MockDependencyContainer)null);
-
 
             // Act
             LogAssert.ignoreFailingMessages = true;
@@ -247,7 +246,7 @@ namespace MonoContainerTests
 
             Assert.That(overrideParent, Is.Null);
             serviceSub.Received(1).FindParentContainer(
-                ContainerRetrievalSetting.Override, container, parentContainer);
+                ParentSetting.Override, container, parentContainer);
         }
     }
 }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Mocks/MockMonoContainerService.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoContainerTests/Mocks/MockMonoContainerService.cs
@@ -14,12 +14,12 @@ namespace MonoContainerTests.Mocks
 
 
         public override MockDependencyContainer FindParentContainer<TUnityContainer, TOverrideContainer>(
-            ContainerRetrievalSetting setting, TUnityContainer unityContainer, 
+            ContainerSetting setting, TUnityContainer unityContainer, 
             TOverrideContainer overrideContainer) =>
             Sub.FindParentContainer(setting, unityContainer, overrideContainer);
 
         public override MockDependencyContainer GetContainer<TOverrideContainer>(
-            ContainerRetrievalSetting setting, bool includeSelf, Transform unityContainer,
+            ContainerSetting setting, bool includeSelf, Transform unityContainer,
             TOverrideContainer overrideContainer) => 
             Sub.GetContainer(setting, includeSelf, unityContainer, overrideContainer);
     }

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoDependencyTests.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/MonoDependencyTests.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 495d270ab5e76034c9730efe28274e85
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/TestHelpers/MonoBehaviourTestExtensions.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/TestHelpers/MonoBehaviourTestExtensions.cs
@@ -30,9 +30,22 @@ namespace TestHelpers
 
             return container;
         }
+
         public static MonoBehaviour SetSerializedProperty(
             this MonoBehaviour container,
             string propertyName, Chopsticks.Dependencies.Containers.ContainerSetting value)
+        {
+            var serializedObject = new SerializedObject(container);
+            var serializedProperty = serializedObject.FindProperty(propertyName);
+
+            serializedProperty.enumValueFlag = (int)value;
+            serializedObject.ApplyModifiedProperties();
+
+            return container;
+        }
+        public static MonoBehaviour SetSerializedProperty(
+            this MonoBehaviour container,
+            string propertyName, Chopsticks.Dependencies.Containers.ContainerRetrievalSetting value)
         {
             var serializedObject = new SerializedObject(container);
             var serializedProperty = serializedObject.FindProperty(propertyName);

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/FindParentContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/FindParentContainer.cs
@@ -60,7 +60,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var parentContainer = service.FindParentContainer(
-                ContainerRetrievalSetting.Global, container, (MonoContainer)null);
+                ContainerSetting.Global, container, (MonoContainer)null);
 
             // Assert
             Assert.That(parentContainer, Is.EqualTo(ContainerService.GlobalContainer));
@@ -74,7 +74,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var parentContainer = service.FindParentContainer(
-                ContainerRetrievalSetting.HierarchyWithGlobal, container, (MonoContainer)null);
+                ContainerSetting.HierarchyWithGlobal, container, (MonoContainer)null);
 
             // Assert
             Assert.That(parentContainer, Is.EqualTo(ContainerService.GlobalContainer));
@@ -88,7 +88,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var parentContainer = service.FindParentContainer(
-                ContainerRetrievalSetting.HierarchyWithGlobal, child, (MonoContainer)null);
+                ContainerSetting.HierarchyWithGlobal, child, (MonoContainer)null);
 
             // Assert
             Assert.That(parentContainer, Is.EqualTo(
@@ -103,7 +103,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var parentContainer = service.FindParentContainer(
-                ContainerRetrievalSetting.HierarchyWithoutGlobal, container, (MonoContainer)null);
+                ContainerSetting.HierarchyWithoutGlobal, container, (MonoContainer)null);
 
             // Assert
             Assert.That(parentContainer, Is.Null);
@@ -117,11 +117,25 @@ namespace UnityContainerServiceTests
 
             // Act
             var parentContainer = service.FindParentContainer(
-                ContainerRetrievalSetting.HierarchyWithoutGlobal, child, (MonoContainer)null);
+                ContainerSetting.HierarchyWithoutGlobal, child, (MonoContainer)null);
 
             // Assert
             Assert.That(parentContainer, Is.EqualTo(
                 (parent as IUnityContainer<DependencyContainer>).NativeContainer));
+        }
+
+        [Test]
+        public void FindParentContainer_NoneRetrievalSetting_Null()
+        {
+            // Set up
+            var service = SetUp.StandardContainer(out var container);
+
+            // Act
+            var parentContainer = service.FindParentContainer(
+                ContainerSetting.None, container, (MonoContainer)null);
+
+            // Assert
+            Assert.That(parentContainer, Is.Null);
         }
 
         [Test]
@@ -132,7 +146,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var parentContainer = service.FindParentContainer(
-                ContainerRetrievalSetting.Override, parent, child);
+                ContainerSetting.Override, parent, child);
 
             // Assert
             Assert.That(parentContainer, Is.Null);
@@ -146,7 +160,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var parentContainer = service.FindParentContainer(
-                ContainerRetrievalSetting.Override, container, container);
+                ContainerSetting.Override, container, container);
 
             // Assert
             Assert.That(parentContainer, Is.Null);
@@ -163,7 +177,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var parentContainer = service.FindParentContainer(
-                ContainerRetrievalSetting.Override, container, overrideContainer);
+                ContainerSetting.Override, container, overrideContainer);
 
             // Assert
             Assert.That(parentContainer, Is.EqualTo(

--- a/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainer.cs
+++ b/Unity/com.chopsticks.dependencies/Assets/Scripts/Tests/Runtime/UnityContainerServiceTests/GetContainer.cs
@@ -60,8 +60,8 @@ namespace UnityContainerServiceTests
 
             // Act
             var serviceContainer = service.GetContainer(
-                ContainerRetrievalSetting.Global,
-                false, (Transform)null, (MonoContainer)null);
+                ContainerSetting.Global,
+                false, null, (MonoContainer)null);
 
             // Assert
             Assert.That(serviceContainer, Is.EqualTo(ContainerService.GlobalContainer));
@@ -75,7 +75,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var serviceContainer = service.GetContainer(
-                ContainerRetrievalSetting.HierarchyWithGlobal, 
+                ContainerSetting.HierarchyWithGlobal, 
                 true, child.transform, (MonoContainer)null);
 
             // Assert
@@ -91,7 +91,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var serviceContainer = service.GetContainer(
-                ContainerRetrievalSetting.HierarchyWithGlobal, 
+                ContainerSetting.HierarchyWithGlobal, 
                 false, container.transform, (MonoContainer)null);
 
             // Assert
@@ -106,7 +106,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var serviceContainer = service.GetContainer(
-                ContainerRetrievalSetting.HierarchyWithGlobal, 
+                ContainerSetting.HierarchyWithGlobal, 
                 false, child.transform, (MonoContainer)null);
 
             // Assert
@@ -122,7 +122,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var serviceContainer = service.GetContainer(
-                ContainerRetrievalSetting.HierarchyWithoutGlobal, 
+                ContainerSetting.HierarchyWithoutGlobal, 
                 true, child.transform, (MonoContainer)null);
 
             // Assert
@@ -138,7 +138,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var serviceContainer = service.GetContainer(
-                ContainerRetrievalSetting.HierarchyWithoutGlobal, 
+                ContainerSetting.HierarchyWithoutGlobal, 
                 false, container.transform, (MonoContainer)null);
 
             // Assert
@@ -153,12 +153,27 @@ namespace UnityContainerServiceTests
 
             // Act
             var serviceContainer = service.GetContainer(
-                ContainerRetrievalSetting.HierarchyWithoutGlobal, 
+                ContainerSetting.HierarchyWithoutGlobal, 
                 false, child.transform, (MonoContainer)null);
 
             // Assert
             Assert.That(serviceContainer, Is.EqualTo(
                 (parent as IUnityContainer<DependencyContainer>).NativeContainer));
+        }
+
+        [Test]
+        public void GetContainer_NoneRetrievalSetting_Null()
+        {
+            // Set up
+            var service = SetUp.StandardContainer(out var container);
+
+            // Act
+            var serviceContainer = service.GetContainer(
+                ContainerSetting.None,
+                false, container.transform, (MonoContainer)null);
+
+            // Assert
+            Assert.That(serviceContainer, Is.Null);
         }
 
         [Test]
@@ -169,7 +184,7 @@ namespace UnityContainerServiceTests
 
             // Act
             var serviceContainer = service.GetContainer(
-                ContainerRetrievalSetting.Override,
+                ContainerSetting.Override,
                 false, (Transform)null, overrideContainer);
 
             // Assert


### PR DESCRIPTION
### What Changed?
- Added a custom editor for MonoDependent and its subclasses, MonoDependency and MonoDependencyWrapper.
- Restricted MonoDependent's parent container setting to the more limited options of ContainerRetrievalSetting, while lessening the restriction of service functions to use ContainerSetting (a superset of ContainerRetrievalSetting).
### Why It Changed
- To provide a custom inspector for those classes that can streamline working with them in the editor.
- To adhere MonoDependent to its logical options for its container while still enabling Containers to have the larger set of options available.
### How to Test
**Verify Functional Custom Editor**
1. Open one of the sample scenes.
2. Select the example configuration GameObject.
3. Verify that all implementations that inherit from MonoDependent have a functional custom editor with titles that are appropriate for each type of implementation.
4. Select one of the handler GameObjects.
5. Verify that its dependent implementation has a functional custom editor.