### PR TITLE
Include PDB Meta

### DIFF
--- a/Unity/com.chopsticks.dependencies/.gitignore
+++ b/Unity/com.chopsticks.dependencies/.gitignore
@@ -48,7 +48,6 @@ ExportedObj/
 
 # Unity3D generated meta files
 *.pidb.meta
-*.pdb.meta
 *.mdb.meta
 
 # Unity3D generated file on crash reports

--- a/Unity/com.chopsticks.dependencies/Assets/Plugins/Chopsticks.Dependencies.pdb.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Plugins/Chopsticks.Dependencies.pdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ea8cbed128dca248852ccdeff3ed854
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/com.chopsticks.dependencies/Assets/Plugins/Chopsticks.Foundation.pdb.meta
+++ b/Unity/com.chopsticks.dependencies/Assets/Plugins/Chopsticks.Foundation.pdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fbc28701abd3d4d4b91fe2851e170eba
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/com.chopsticks.messages/.gitignore
+++ b/Unity/com.chopsticks.messages/.gitignore
@@ -48,7 +48,6 @@ ExportedObj/
 
 # Unity3D generated meta files
 *.pidb.meta
-*.pdb.meta
 *.mdb.meta
 
 # Unity3D generated file on crash reports

--- a/Unity/com.chopsticks.messages/Assets/Plugins/Chopsticks.Foundation.pdb.meta
+++ b/Unity/com.chopsticks.messages/Assets/Plugins/Chopsticks.Foundation.pdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3fe3bc3b1283f38459fc04902cdd8148
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/com.chopsticks.messages/Assets/Plugins/Chopsticks.Messages.pdb.meta
+++ b/Unity/com.chopsticks.messages/Assets/Plugins/Chopsticks.Messages.pdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a88058bdcd247ee45bfea6e9e4a1abd1
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/com.chopsticks.messages/package.json
+++ b/Unity/com.chopsticks.messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.chopsticks.messages",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "displayName": "Chopsticks Messages",
   "description": "Provides functionality to support messages within Unity.",
   "unity": "2023.2",


### PR DESCRIPTION
### What Changed?
- Include the meta of the PDB files.
### Why It Changed
- To enable Unity to properly load and read the PDB files.