### PR TITLE
Patch MulticastContextHandler Registering Context Handlers.

### DIFF
--- a/Native/Messages/Handlers/Multicast/MulticastContextHandler.cs
+++ b/Native/Messages/Handlers/Multicast/MulticastContextHandler.cs
@@ -39,7 +39,7 @@ public class MulticastContextHandler<TMessage, TContext> :
         IContextHandler<TMessage, TContext> handler,
         HandlerRegistrationSettings settings)
     {
-        var registration = new RegisteredMessageHandler<TMessage, TContext>(handler)
+        var registration = new RegisteredContextHandler<TMessage, TContext>(handler)
         {
             Order = settings.Order
         };

--- a/Unity/com.chopsticks.messages/package.json
+++ b/Unity/com.chopsticks.messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.chopsticks.messages",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "displayName": "Chopsticks Messages",
   "description": "Provides functionality to support messages within Unity.",
   "unity": "2023.2",


### PR DESCRIPTION
### What Changed?
- Ensured registered context handlers are registered as context handlers.
### Why It Changed
- To maintain context changes through the pipeline to the handler call.